### PR TITLE
Various Cutscene Skips

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -909,6 +909,12 @@ F100: # Faron main area
     layer: 1
     room: 0
     objtype: OBJ
+  - name: Remove Fi text after shooting down vine to deep woods
+    type: objdelete
+    id: 0x46BE
+    layer: 1
+    room: 0
+    objtype: OBJ
 F101: # Deep Woods
   - name: Layer override
     type: layeroverride
@@ -928,6 +934,12 @@ F101: # Deep Woods
   - name: Remove Fi text infront of Skyview
     type: objdelete
     id: 0xFCFA
+    layer: 1
+    room: 0
+    objtype: OBJ
+  - name: Remove first Fi text in deep woods
+    type: objdelete
+    id: 0xFD09
     layer: 1
     room: 0
     objtype: OBJ
@@ -1196,6 +1208,12 @@ D100: # Skyview
     id: 0xFC34
     layer: 2
     room: 7
+    objtype: OBJ
+  - name: Remove initial Fi text in Skyview 2
+    type: objdelete
+    id: 0xFC4A
+    layer: 2
+    room: 0
     objtype: OBJ
       
 D101: # Ancient Cistern
@@ -1821,6 +1839,12 @@ D301: # Sandship A
     id: 0xFC12
     layer: 1
     room: 5
+    objtype: OBJ
+  - name: Fi text after boss key chest
+    type: objdelete
+    id: 0xFC1D
+    layer: 3
+    room: 14
     objtype: OBJ
 F402: # Sealed Temple
   - name: SotH start cs

--- a/patches.yaml
+++ b/patches.yaml
@@ -1753,6 +1753,25 @@ F301: # Ancient Harbour
     layer: 0
     room: 0
     objtype: OBJ
+F301_2: # inside Pirate Stronghold
+  - name: Fi Text at beginning
+    type: objdelete
+    id: 0xFC0A
+    layer: 0
+    room: 1
+    objtype: OBJ
+  - name: Fi Text near timeshift orb
+    type: objdelete
+    id: 0xFC06
+    layer: 0
+    room: 3
+    objtype: OBJ
+  - name: Fi Text after placing orb
+    type: objdelete
+    id: 0xFC0B
+    layer: 0
+    room: 1
+    objtype: OBJ
 F301_4: # Shipyard
   - name: Text after intro
     type: objdelete

--- a/patches.yaml
+++ b/patches.yaml
@@ -823,6 +823,12 @@ F023: # Thunderhead
       anglez: 0xFFFF
       id: 0xFC00
       name: PlRsTag
+  - name: Delete Isle of Songs intro cutscene
+    type: objdelete
+    id: 0xFC89
+    layer: 0
+    room: 0
+    objtype: OBJ
 F100: # Faron main area
   - name: Layer override
     type: layeroverride
@@ -1265,6 +1271,12 @@ D101: # Ancient Cistern
       anglez: 0
       id: 0xFD01
       name: Bombf
+  - name: Delete cutscene inside statue
+    type: objdelete
+    id: 0xFC21
+    layer: 0
+    room: 10
+    objtype: STAG
 F200: # Eldin main area
   - name: Layer override
     type: layeroverride
@@ -1577,6 +1589,19 @@ F300_2: # Thunder node
       anglez: 0
       id: 0xFC50
       name: Bombf
+  - name: Fi text for generator
+    type: objdelete
+    id: 0xFC24
+    layer: 0
+    room: 0
+    objtype: OBJ
+F300_3: # Fire node
+  - name: Fi text for generator
+    type: objdelete
+    id: 0xFC28
+    layer: 0
+    room: 0
+    objtype: OBJ
 F300_4: # Temple of Time
   - name: Layer override
     type: layeroverride
@@ -1845,6 +1870,13 @@ D301: # Sandship A
     id: 0xFC1D
     layer: 3
     room: 14
+    objtype: OBJ
+F303: # Lanayru Caves
+  - name: Fi text after chest
+    type: objdelete
+    id: 0xFC25
+    layer: 0
+    room: 0
     objtype: OBJ
 F402: # Sealed Temple
   - name: SotH start cs


### PR DESCRIPTION
Cutscenes deleted:
- Isle of Songs Intro cutscene
- Fi text for deep woods vine
- Initial Fi text in deep woods
- Initial Fi text in Skyview 2
- Cutscene inside Statue in Ancient Cistern
- Generator Fi text for both the Fire Node and the Thunder Node
- Fi text after boss key chest in Sandship
- Fi text after chest in lanayru caves

There's definitely more but we will figure them out while playing more