### PR TITLE
Various Cutscene Skips 2

### DIFF
--- a/SS Rando Logic - Macros.yaml
+++ b/SS Rando Logic - Macros.yaml
@@ -210,8 +210,8 @@ Can Beat Ancient Cistern:
     Can Access Ancient Cistern & Whip & AC Boss Key & (AC Small Key x2 | Clawshots) & Goddess Sword
 
 Can Access Dungeon Entrance In Sand Sea:
-    Can Access Sand Sea & Sea Chart & Goddess Sword
-    # Goddess Sword needed to dowse
+    Can Access Sand Sea & Sea Chart & Practice Sword
+    # You need any sword to be able to dowse
 
 Can Beat Sandship:
     Can Access Sandship & Bow & SS Boss Key & Goddess Sword
@@ -228,9 +228,6 @@ Can Beat Fire Sanctuary:
 # Can Access Past:
 #     this is filled in at runtime with the required dungeons
 
-#Can Access Levias:
-#    Can Access Past
-
 #Can Access/Beat Flooded Faron:
 #    Can Access Levias & Water Scale
 
@@ -241,7 +238,8 @@ Can Beat Fire Sanctuary:
 #    Can Access Lanayru & Can Access Levias & Clawshots
 
 #Can Heal Thunder Dragon:
-#    Can Access Lanayru Gorge & Life Tree Seedling & Bomb Bag & Clawshots & Hook Beetle & Whip & Can Access Past?
+#    Can Access Lanayru Gorge & Life Tree Fruit & Clawshots & Hook Beetle & Whip & Can Defeat Beamos
+# # Note that the minecart escort is a softlock if done without a way to defeat the beamos or without whip (although maybe dying is always possible? not sure)
 
 Can Access Dungeon Entrance On Skyloft:
     Stone of Trials & Clawshots

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -1017,7 +1017,7 @@
   - name: Statue Lower Question
     type: textpatch
     index: 9
-    text: "Do you want to lower the Statue?\n\x0E\x01\x00\x02\uFFFFYes\x0E\x01\x01\x02\x00No"
+    text: "Do you want to reset the statue?\n\x0E\x01\x00\x02\uFFFFYes\x0E\x01\x01\x02\x00No"
   - name: Replace Stone Tablet Fi Event
     type: flowpatch
     index: 7
@@ -1300,6 +1300,12 @@
       param2: 7
       next: -1
       param3: 7
+402-DesertF2:
+  - name: Never ask player to go inside shark mouth for ship dowsing
+    type: flowpatch
+    index: 17
+    flow:
+      next: 276
 450-DesertSiren:
   - name: to unset trial storyflag
     type: flowpatch

--- a/patches.yaml
+++ b/patches.yaml
@@ -406,6 +406,58 @@ B301: # after Sandship boss
     object:
       params1: 0xC303FF03 # change to zone temp flag 3
       anglez: 0xFFFF # don't set any storyflag here
+D003_0: # Skykeep Courage Room
+  - name: Fi text
+    type: objdelete
+    id: 0xFC0F
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Fi text reach the mark
+    type: objdelete
+    id: 0xFC11
+    layer: 0
+    room: 0
+    objtype: OBJ
+D003_2: # Skykeep Power Room
+  - name: Fi text
+    type: objdelete
+    id: 0xFC33
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Fi text reach the mark
+    type: objdelete
+    id: 0xFC3C
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Fi text wrong side
+    type: objdelete
+    id: 0xFC32
+    layer: 0
+    room: 0
+    objtype: OBJ
+D003_3: # Skykeep Wisdom Room
+  - name: Fi text
+    type: objdelete
+    id: 0xFC1B
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Fi text reach the mark
+    type: objdelete
+    id: 0xFC1D
+    layer: 0
+    room: 0
+    objtype: OBJ
+D003_7: # Skykeep Entrance Room
+  - name: Fi text
+    type: objdelete
+    id: 0xFC0B
+    layer: 0
+    room: 0
+    objtype: OBJ
 F000: # Skyloft
   - name: Trial
     type: oarcadd
@@ -704,6 +756,19 @@ F001r: # Knight Academy
     objtype: OBJ
     object:
       untrigstoryfid: 57 # talk to Elder after locating every Kikwi
+F002r: # Beedle's Airshop
+  - name: Delete cutscene
+    type: objdelete
+    id: 0xFC11
+    layer: 1
+    room: 0
+    objtype: STAG
+  - name: Delete cutscene
+    type: objdelete
+    id: 0xFC13
+    layer: 1
+    room: 0
+    objtype: STAG
 F004r: # Bazaar
   - name: Delete goddess chest fi text
     type: objdelete
@@ -810,6 +875,19 @@ F010r: # Isle of songs tower
   - name: Delete Eldin Trial Dowsing
     type: objdelete
     id: 0xFC04
+    layer: 0
+    room: 0
+    objtype: OBJ
+F011r: # Lumpy Pumpkin
+  - name: Delete Lumpy Pumpkin Cutscene 1
+    type: objdelete
+    id: 0xFC42
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Delete Lumpy Pumpkin Cutscene 2
+    type: objdelete
+    id: 0xFC43
     layer: 0
     room: 0
     objtype: OBJ
@@ -1340,7 +1418,12 @@ D100: # Skyview
     layer: 2
     room: 0
     objtype: OBJ
-      
+  - name: Remove cutscene in hub room
+    type: objdelete
+    id: 0xFC85
+    layer: 1
+    room: 5
+    objtype: STAG
 D101: # Ancient Cistern
   - name: remove stone tablet text
     type: objpatch
@@ -1395,6 +1478,12 @@ D101: # Ancient Cistern
     id: 0xFC21
     layer: 0
     room: 10
+    objtype: STAG
+  - name: Delete cutscene in basement showing bk chest
+    type: objdelete
+    id: 0xFC7E
+    layer: 0
+    room: 4
     objtype: STAG
 F200: # Eldin main area
   - name: Layer override
@@ -1553,6 +1642,24 @@ F201_3: # FS entrance
     layer: 0
     room: 0
     objtype: OBJ
+  - name: Goron Text after first frog
+    type: objdelete
+    id: 0xFC5A
+    layer: 2
+    room: 0
+    objtype: OBJ
+  - name: Goron Text after second frog
+    type: objdelete
+    id: 0xFC5B
+    layer: 2
+    room: 0
+    objtype: OBJ
+  - name: Goron Text near big frog
+    type: objdelete
+    id: 0xFC5C
+    layer: 2
+    room: 0
+    objtype: OBJ
 F201_4: # Volcano Waterfall
   - name: extra Bomb flower
     type: objadd
@@ -1627,7 +1734,7 @@ D201: # FS A
     room: 0
     objtype: OBJ
 D201_1: # FS B
-  - name: Clawshot Traget for 2nd small Key
+  - name: Clawshot Target for 2nd small Key
     type: objadd
     layer: 0
     room: 5
@@ -1656,6 +1763,18 @@ D201_1: # FS B
     index: 1
     object:
       story_flag1: -1
+  - name: Delete Camera Pan in first magmanos room
+    type: objdelete
+    id: 0xFC1B
+    layer: 0
+    room: 1
+    objtype: STAG
+  - name: Underground tutorial text for mogma mitts
+    type: objdelete
+    id: 0xFC66
+    layer: 0
+    room: 5
+    objtype: OBJ
 B201: # G2 fight
   - name: Layer override
     type: layeroverride
@@ -1713,7 +1832,13 @@ F300: # lanayru Main Area
     layer: 0
     room: 0
     objtype: OBJ
-F300_1:
+  - name: Remove Fi text for all nodes
+    type: objdelete
+    id: 0x0CC4
+    layer: 0
+    room: 0
+    objtype: OBJ
+F300_1: # Lanayru Mines
   - name: Layer override
     type: layeroverride
     override:
@@ -1763,10 +1888,22 @@ F300_2: # Thunder node
     layer: 0
     room: 0
     objtype: OBJ
+  - name: Remove Fi text for all nodes
+    type: objdelete
+    id: 0xFC23
+    layer: 0
+    room: 0
+    objtype: OBJ
 F300_3: # Fire node
   - name: Fi text for generator
     type: objdelete
     id: 0xFC28
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Remove Fi text for all nodes
+    type: objdelete
+    id: 0xFC27
     layer: 0
     room: 0
     objtype: OBJ
@@ -1913,6 +2050,12 @@ F301_1: # Sand Sea Main Area
     room: 0
     objtype: STAG
     id: 0xFC6B
+  - name: Cutscene after shipyard
+    type: objdelete
+    id: 0xFC07
+    layer: 0
+    room: 0
+    objtype: OBJ
 F301: # Ancient Harbour
   - name: No Sandship beaten layer in sandship
     type: objpatch
@@ -1946,6 +2089,13 @@ F301_2: # inside Pirate Stronghold
     layer: 0
     room: 1
     objtype: OBJ
+F301_3: # Skipper's Retreat
+  - name: Text after intro
+    type: objdelete
+    id: 0xFC30
+    layer: 0
+    room: 0
+    objtype: OBJ
 F301_4: # Shipyard
   - name: Text after intro
     type: objdelete
@@ -1960,7 +2110,20 @@ F301_4: # Shipyard
     objtype: EVNT
     object:
       sceneflag2: 87
+F301_5: # Skipper's Shack
+  - name: Text after chest
+    type: objdelete
+    id: 0xFC1B
+    layer: 0
+    room: 0
+    objtype: OBJ
 F301_6: # outside Pirate stronghold
+  - name: Text after intro
+    type: objdelete
+    id: 0xFC07
+    layer: 0
+    room: 0
+    objtype: OBJ
   - name: Ship dowsing
     type: objdelete
     id: 0xFC08
@@ -1968,6 +2131,12 @@ F301_6: # outside Pirate stronghold
     room: 0
     objtype: OBJ
 F301_7: # inside Shipyard
+  - name: Text near minecart door
+    type: objdelete
+    id: 0xFC04
+    layer: 0
+    room: 0
+    objtype: OBJ
   - name: Door to outside
     type: objpatch
     id: 0xFC01
@@ -2098,6 +2267,19 @@ D301: # Sandship A
     layer: 1
     room: 0
     objtype: OBJ
+D301_1: # Sandship B
+  - name: Fi text before tentacles
+    type: objdelete
+    id: 0xFC1D
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Fi text before tentalus
+    type: objdelete
+    id: 0xFC1E
+    layer: 0
+    room: 0
+    objtype: OBJ
 F303: # Lanayru Caves
   - name: Layer override
     type: layeroverride
@@ -2114,6 +2296,12 @@ F303: # Lanayru Caves
     layer: 0
     room: 0
     objtype: OBJ
+  - name: Delete cutscene
+    type: objdelete
+    id: 0xFC41
+    layer: 0
+    room: 0
+    objtype: STAG
   - name: never untrigger goron
     type: objpatch
     id: 0xFC5C
@@ -2301,6 +2489,12 @@ F401: # Sealed grounds Whirlpool
     onlyif: Option "skip-skykeep" Enabled
     object:
       sceneflag2: 50 # door to horde open
+  - name: Fi text for Trial
+    type: objdelete
+    id: 0xFC09
+    layer: 0
+    room: 1
+    objtype: OBJ
 F400: # Behind the Temple
   - name: Layer override
     type: layeroverride
@@ -2342,6 +2536,26 @@ F400: # Behind the Temple
     objtype: OBJ
     object:
       untrigstoryfid: 2047
+  - name: Goron after Skyview
+    type: objdelete
+    id: 0xFC2E
+    layer: 0
+    room: 0
+    objtype: OBJ
+  - name: Untrigger Goron with Goddess Walls unlocked
+    type: objpatch
+    id: 0xFC2F
+    layer: 0
+    room: 0
+    objtype: OBJ
+    object:
+      untrigstoryfid: 493 #godess walls unlocked
+  - name: Fi text for Trial
+    type: objdelete
+    id: 0xFC5B
+    layer: 0
+    room: 0
+    objtype: OBJ
 F404: # Hylia's Temple
   - name: Layer override
     type: layeroverride


### PR DESCRIPTION
- Change Stone Tablet Text in Ancient Cistern (it's not "lower" when the statue already is).
- Change Skipper's Event in Stronghold to prevent him showing you where the ship dowsing was in the vanilla game
- Remove all Fi texts in Sky Keep (except the one after the first control panel)
- Remove Beedle's airshop ship intro cutscene
- Remove Lumpy Pumpkin intro cutscene
- Remove cutscene in hub room in Skyview 1
- Remove cutscene showing boss key chest in Ancient Cistern, near AC bokoblin
- Remove all Goron texts in FS Entrance except the first one (Suggestion: make him appear after Goddess White Sword so that getting Goddess Cube dowsing doesn't look weird?)
- Remove short camera pan in first magmanos room in FS
- Delete mogma mitts tutorial in underground section
- Remove Fi Text for activating all the nodes
- Remove Skipper's intro texts in Skipper's Retreat and Pirate Stronghold (consistency with Shipyard)
- Remove Skipper's cutscene in Sand Sea after beating Molderach 2
- Remove long cutscene after opening the chest in Skipper's shack
- Remove Fi Texts in Sandship B (Sandship escape sequence)
- Remove Lanayru Cave intro cutscene
- Remove Fi Text for Faron Trial Gate in all sealed grounds areas
- Attempt at preventing duplicate Goron at behind the temple

More suggestions (that this PR doesn't do, maybe another day):
- Start the game with skyloft scene flags 2x04 and 6x01
- Prevent Groose skydiving when not having Farore's Courage (this one will make some people sad)
- Fix all duplicates inside Sealed Temple (idk how many there are)
- More cutscene skips in Fire Sanctuary probably (but changing the events there feels a bit scary)

Note for later: You can't just delete the Fi text before bonking the Lopsa tree and be done with it, because it messes up Lopsa's event

EDIT: I guess I will also use this PR to fix a few logic things