### PR TITLE
More options

### DIFF
--- a/SS Rando Logic - Item Location.yaml
+++ b/SS Rando Logic - Item Location.yaml
@@ -151,7 +151,7 @@ Skyloft - Parrow Crystals:
 Skyloft - Fledge Crystals:
   Need: Can Beat Lanayru Mining Facility & Bottle # LMF only for Potion right now
   original item: 5 Gratitude Crystals
-  type: skyloft, short, crystal quest, dungeon
+  type: skyloft, lanayru, short, crystal quest, dungeon
   Paths:
     - event/115-Town2/325
     - oarc/F001r/l0
@@ -173,7 +173,7 @@ Skyloft - Ghost/Pipit Crystals:
 Skyloft - Sparrot Crystals:
   Need: Can Access Second Part of Eldin & Clawshots
   original item: 5 Gratitude Crystals
-  type: skyloft, long, scrapper, crystal quest
+  type: skyloft, eldin, long, scrapper, crystal quest
   Paths:
     - event/118-Town3/141
     - oarc/F013r/l0
@@ -187,7 +187,7 @@ Skyloft - Cleaning Crystals:
 Skyloft - Owlan Crystals:
   Need: Can Access Most of Faron Woods & Bomb Bag
   original item: 5 Gratitude Crystals
-  type: skyloft, long, scrapper, crystal quest
+  type: skyloft, faron, long, scrapper, crystal quest
   Paths:
     - event/118-Town3/157
     - oarc/F001r/l0
@@ -421,14 +421,14 @@ Sky - Southwest Triple Island Cage Goddess Cube:
 Sky - Fun Fun Island Minigame:
   Need: Can Retrieve Party Wheel
   original item: Heart Piece
-  type: sky, minigame, long, scrapper
+  type: sky, lanayru, minigame, long, scrapper
   Paths:
    - event/110-DivingGame/19
    - oarc/F020/l2
 Sky - Dohdoh Crystals:
   Need: Can Retrieve Party Wheel
   original item: 5 Gratitude Crystals
-  type: sky, long, scrapper
+  type: sky, lanayru, long, scrapper
   Paths:
     - event/110-DivingGame/60
     - oarc/F020/l0
@@ -436,14 +436,14 @@ Sky - Orrielle Crystals:
   Need: Bottle
   # Need access to Faron to be able to get mushroom spores as many times as you want
   original item: 5 Gratitude Crystals
-  type: short, crystal quest
+  type: sky, short, crystal quest
   Paths:
     - event/115-Town2/225
     - oarc/F020/l0
 Sky - Kina Crystals:
   Need: Bottle & Goddess Harp & Can Access Eldin
   original item: 5 Gratitude Crystals
-  type: sky, scrapper, minigame, long, crystal quest
+  type: sky, eldin, scrapper, minigame, long, crystal quest
   Paths:
     - event/117-Pumpkin/386
     - oarc/F020/l0
@@ -491,7 +491,7 @@ Thunderhead - Goddess Chest Outside Isle of Song:
 Thunderhead - Goddess Chest on top of Isle of Song:
   Need: Can Access Thunderhead & Goddess Cube near FS Entrance
   original item: Small Bomb Bag
-  type: goddess, summit goddess
+  type: thunderhead, goddess, summit goddess
   Paths:
    - stage/F023/r0/l0/TBox/85
 Thunderhead - East Island Goddess Chest:
@@ -534,7 +534,7 @@ Thunderhead - Bug Island minigame:
 Thunderhead - Levias:
   Need: Can Access Thunderhead & Spiral Charge & Practice Sword
   original item: Song of the Hero
-  type: thunderhead, scrapper, combat, song
+  type: thunderhead, sky, scrapper, combat, song
   Paths:
    - event/120-Nushi/give item after levias
    - oarc/F023/l0

--- a/SS Rando Logic - Item Location.yaml
+++ b/SS Rando Logic - Item Location.yaml
@@ -1562,31 +1562,31 @@ Fire Sanctuary - Din's Flame:
 Skykeep - Map Chest:
   Need: Can Access Skykeep
   original item: Skykeep Map
-  type: sky, dungeon
+  type: skyloft, dungeon
   Paths:
    - stage/D003_7/r0/l0/TBox/64
 Skykeep - Small Key Chest:
   Need: Can Access Skykeep & Gust Bellows & Whip & Bow & Clawshots & Practice Sword
   original item: Skykeep Small Key
-  type: sky, dungeon
+  type: skyloft, dungeon
   Paths:
    - stage/D003_6/r0/l0/TBox/65
 #Skykeep - Triforce of Wisdom Event
 #   Need: Can Access Skykeep & Gust Bellows & Whip & Bow & Clawshots
 #   original item: Triforce of Wisdom
-#   type: dungeon
+#   type: skyloft, dungeon
 #   Paths:
 #    - stage/D003_8.json
 #Skykeep - Triforce of Power Event
 #   Need: Can Access Skykeep & Gust Bellows & Whip & Bow & Clawshots
 #   original item: Triforce of Power
-#   type: dungeon
+#   type: skyloft, dungeon
 #   Paths:
 #    - stage/D003_8.json
 #Skykeep - Triforce of Courage Event
 #   Need: Can Access Skykeep & Gust Bellows & Whip & Bow & Clawshots & Skykeep Small Key x1
 #   original item: Triforce of Courage
-#   type: dungeon
+#   type: skyloft, dungeon
 #   Paths:
 #    - stage/D003_8.json
 

--- a/SS Rando Logic - Item Location.yaml
+++ b/SS Rando Logic - Item Location.yaml
@@ -1,7 +1,7 @@
 Skyloft - Fledge:
   Need: Nothing
   original item: Progressive Pouch
-  type: sky, free gift
+  type: skyloft, free gift
   Paths:
     - event/114-Friend/16
     - oarc/F001r/l3
@@ -9,7 +9,7 @@ Skyloft - Fledge:
 Skyloft - Owlan's Shield:
   Need: Nothing
   original item: Wooden Shield
-  type: sky, free gift
+  type: skyloft, free gift
   Paths:
    - event/108-ShinkanA/169
    - oarc/F000/l4
@@ -17,80 +17,80 @@ Skyloft - Owlan's Shield:
 Skyloft - Practice Sword:
   Need: Nothing
   original item: Progressive Sword
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
    - stage/F009r/r0/l0/TBox/66
 Skyloft - Bazaar Potion Lady:
   Need: Nothing
   original item: Bottle
-  type: sky, free gift
+  type: skyloft, free gift
   Paths:
    - event/106-DrugStore/44
    - oarc/F004r/l0
 Skyloft - Waterfall Cave First Chest:
   Need: (Practice Sword | Bomb Bag)
   original item: Red Rupee
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
    - stage/D000/r0/l0/TBox/67
 Skyloft - Waterfall Cave Second Chest:
   Need: (Practice Sword | Bomb Bag)
   original item: Red Rupee
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
    - stage/D000/r0/l0/TBox/68
 Skyloft - Small Chest on Cliffs Near Goddess Statue:
   Need: Nothing
   original item: Red Rupee
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
    - stage/F000/r0/l0/TBox/71
 Skyloft - Goddess Sword:
   Need: Nothing
   original item: Progressive Sword
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
     - stage/F008r/r0/l0/TBox/95
 Skyloft - Bazaar Goddess Chest:
   Need: Goddess Cube in Ancient Harbour
   original item: Gold Rupee
-  type: sky, goddess, sand sea goddess
+  type: skyloft, goddess, sand sea goddess
   Paths:
    - stage/F004r/r0/l0/TBox/93
 Skyloft - Shed Chest:
   Need: Water Scale
   original item: Silver Rupee
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
    - stage/F000/r0/l0/TBox/70
 Skyloft - Shed Goddess Chest:
   Need: Water Scale & Goddess Cube in Eldin Slide
   original item: Heart Piece
-  type: sky, goddess, eldin goddess
+  type: skyloft, goddess, eldin goddess
   Paths:
    - stage/F000/r0/l0/TBox/79
 Skyloft - West Cliff Goddess Chest:
   Need: Goddess Cube on West Great Tree near exit
   original item: Silver Rupee
-  type: sky, goddess, faron goddess
+  type: skyloft, goddess, faron goddess
   Paths:
    - stage/F000/r0/l0/TBox/78
 Skyloft - Floating Island Goddess Chest:
   Need: Clawshots & Goddess Cube in Lake Floria
   original item: Gold Rupee
-  type: sky, goddess, floria goddess
+  type: skyloft, goddess, floria goddess
   Paths:
    - stage/F000/r0/l0/TBox/91
 Skyloft - Waterfall Goddess Chest:
   Need: Clawshots & Goddess Cube in Pirate Stronghold
   original item: Heart Piece
-  type: sky, goddess, sand sea goddess
+  type: skyloft, goddess, sand sea goddess
   Paths:
    - stage/F000/r0/l0/TBox/80
 Skyloft - Pumpkin Archery - 600 Points:
   Need: Bow
   original item: Heart Piece
-  type: sky, minigame
+  type: skyloft, minigame
   Paths:
    - event/114-Friend/99
    - oarc/F000/l4
@@ -98,19 +98,19 @@ Skyloft - Pumpkin Archery - 600 Points:
 Skyloft - Zelda Heartpiece:
   Need: Clawshots
   original item: Heart Piece
-  type: sky, miscellaneous
+  type: skyloft, miscellaneous
   Paths:
    - stage/F001r/r6/l0/chest/32 #sceneflag
 Skyloft - Baby Rattle:
   Need: Gust Bellows & Clawshots #needs work, note that it's possible to get there from Beetle's airship
   original item: Baby's Rattle
-  type: sky, freestanding
+  type: skyloft, freestanding
   Paths:
     - stage/F000/r0/l0/Item/13
 Skyloft - Parrow's Bottle:
   Need: Nothing
   original item: Bottle
-  type: sky, free gift, short
+  type: skyloft, free gift, short
   Paths:
     - event/115-Town2/230 # mushroom spores
     - event/115-Town2/733 # Bottle
@@ -119,21 +119,21 @@ Skyloft - Parrow's Bottle:
 Skyloft - Cawlin's Letter:
   Need: Goddess Harp
   original item: Cawlin's Letter
-  type: sky, short
+  type: skyloft, short
   Paths:
     - event/115-Town2/166
     - oarc/F001r/l0
 Skyloft - Wyrna Crystals:
   Need: Nothing
   original item: 5 Gratitude Crystals
-  type: sky, free gift, crystal quest
+  type: skyloft, free gift, crystal quest
   Paths:
     - event/118-Town3/144
     - oarc/F006r/l0
 Skyloft - Peater/Peatrice Crystals:
   Need: Nothing
   original item: 5 Gratitude Crystals
-  type: sky, long, crystal quest, peatrice
+  type: skyloft, long, crystal quest, peatrice
   Paths:
     - event/109-TakeGoron/79
     - event/123-Town5/316
@@ -143,7 +143,7 @@ Skyloft - Parrow Crystals:
   Need: Bottle
     # There are mushrooms in the Sky inside the Volcanic Island
   original item: 5 Gratitude Crystals
-  type: sky, short, crystal quest
+  type: skyloft, short, crystal quest
   Paths:
     - event/115-Town2/814
     - oarc/F000/l0
@@ -151,21 +151,21 @@ Skyloft - Parrow Crystals:
 Skyloft - Fledge Crystals:
   Need: Can Beat Lanayru Mining Facility & Bottle # LMF only for Potion right now
   original item: 5 Gratitude Crystals
-  type: sky, short, crystal quest, dungeon
+  type: skyloft, short, crystal quest, dungeon
   Paths:
     - event/115-Town2/325
     - oarc/F001r/l0
 Skyloft - Baby Crystals:
   Need: Baby Rattle
   original item: 5 Gratitude Crystals
-  type: sky, fetch, crystal quest
+  type: skyloft, fetch, crystal quest
   Paths:
     - event/115-Town2/125
     - oarc/F014r/l0
 Skyloft - Ghost/Pipit Crystals:
   Need: Cawlin's Letter
   original item: 5 Gratitude Crystals
-  type: sky, fetch, crystal quest
+  type: skyloft, fetch, crystal quest
   Paths:
     - event/115-Town2/522
     - event/115-Town2/641
@@ -173,21 +173,21 @@ Skyloft - Ghost/Pipit Crystals:
 Skyloft - Sparrot Crystals:
   Need: Can Access Second Part of Eldin & Clawshots
   original item: 5 Gratitude Crystals
-  type: sky, long, scrapper, crystal quest
+  type: skyloft, long, scrapper, crystal quest
   Paths:
     - event/118-Town3/141
     - oarc/F013r/l0
 Skyloft - Cleaning Crystals:
   Need: Gust Bellows
   original item: 5 Gratitude Crystals
-  type: sky, short, crystal quest
+  type: skyloft, short, crystal quest
   Paths:
     - event/123-Town5/186
     - oarc/F016r/l0
 Skyloft - Owlan Crystals:
   Need: Can Access Most of Faron Woods & Bomb Bag
   original item: 5 Gratitude Crystals
-  type: sky, long, scrapper, crystal quest
+  type: skyloft, long, scrapper, crystal quest
   Paths:
     - event/118-Town3/157
     - oarc/F001r/l0
@@ -196,62 +196,62 @@ Skyloft - Owlan Crystals:
 Skyloft - Batreaux 5 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & (5 Gratitude Crystals | Gratitude Crystal x5) # since 5 packs are randomized, it's possible to get crystals without being able to meet batreaux
   original item: Progressive Wallet
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/21
     - oarc/F012r/l0
 Skyloft - Batreaux 10 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 10 Gratitude Crystals
   original item: Heart Piece
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/42
     - oarc/F012r/l0
 Skyloft - Batreaux 30 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 30 Gratitude Crystals # 30 gratitude Crystals
   original item: Progressive Wallet
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/24
     - oarc/F012r/l0
 Skyloft - Batreaux 30 Crystals Chest:
   Need: Can Open Batreaux Shed & 30 Gratitude Crystals # 30 gratitude Crystals
   original item: Cursed Medal
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - stage/F012r/r0/l0/TBox/69
 Skyloft - Batreaux 40 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 40 Gratitude Crystals # 40 gratitude Crystals
   original item: Gold Rupee
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/49
     - oarc/F012r/l0
 Skyloft - Batreaux 50 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 50 Gratitude Crystals # 50 gratitude Crystals
   original item: Progressive Wallet
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/27
     - oarc/F012r/l0
 Skyloft - Batreaux 70 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 70 Gratitude Crystals # 70 gratitude Crystals
   original item: Gold Rupee
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/161
     - oarc/F012r/l0
 Skyloft - Batreaux 70 Crystals Second Reward:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 70 Gratitude Crystals # 70 gratitude Crystals
   original item: Gold Rupee
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/163
     - oarc/F012r/l0
 Skyloft - Batreaux 80 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 80 Gratitude Crystals # 80 gratitude Crystals
   original item: Progressive Wallet
-  type: sky, batreaux
+  type: skyloft, batreaux
   Paths:
     - event/121-AkumaKun/37
     - oarc/F012r/l0

--- a/SS Rando Logic - Item Location.yaml
+++ b/SS Rando Logic - Item Location.yaml
@@ -1,7 +1,7 @@
 Skyloft - Fledge:
   Need: Nothing
   original item: Progressive Pouch
-  type: quest
+  type: sky, free gift
   Paths:
     - event/114-Friend/16
     - oarc/F001r/l3
@@ -9,7 +9,7 @@ Skyloft - Fledge:
 Skyloft - Owlan's Shield:
   Need: Nothing
   original item: Wooden Shield
-  type: quest
+  type: sky, free gift
   Paths:
    - event/108-ShinkanA/169
    - oarc/F000/l4
@@ -17,80 +17,80 @@ Skyloft - Owlan's Shield:
 Skyloft - Practice Sword:
   Need: Nothing
   original item: Progressive Sword
-  type: overworld
+  type: sky, miscellaneous
   Paths:
    - stage/F009r/r0/l0/TBox/66
 Skyloft - Bazaar Potion Lady:
   Need: Nothing
   original item: Bottle
-  type: quest
+  type: sky, free gift
   Paths:
    - event/106-DrugStore/44
    - oarc/F004r/l0
 Skyloft - Waterfall Cave First Chest:
   Need: (Practice Sword | Bomb Bag)
   original item: Red Rupee
-  type: overworld
+  type: sky, miscellaneous
   Paths:
    - stage/D000/r0/l0/TBox/67
 Skyloft - Waterfall Cave Second Chest:
   Need: (Practice Sword | Bomb Bag)
   original item: Red Rupee
-  type: overworld
+  type: sky, miscellaneous
   Paths:
    - stage/D000/r0/l0/TBox/68
 Skyloft - Small Chest on Cliffs Near Goddess Statue:
   Need: Nothing
   original item: Red Rupee
-  type: overworld
+  type: sky, miscellaneous
   Paths:
    - stage/F000/r0/l0/TBox/71
 Skyloft - Goddess Sword:
   Need: Nothing
   original item: Progressive Sword
-  type: overworld
+  type: sky, miscellaneous
   Paths:
     - stage/F008r/r0/l0/TBox/95
 Skyloft - Bazaar Goddess Chest:
   Need: Goddess Cube in Ancient Harbour
   original item: Gold Rupee
-  type: goddess
+  type: sky, goddess, sand sea goddess
   Paths:
    - stage/F004r/r0/l0/TBox/93
 Skyloft - Shed Chest:
   Need: Water Scale
   original item: Silver Rupee
-  type: overworld
+  type: sky, miscellaneous
   Paths:
    - stage/F000/r0/l0/TBox/70
 Skyloft - Shed Goddess Chest:
   Need: Water Scale & Goddess Cube in Eldin Slide
   original item: Heart Piece
-  type: goddess
+  type: sky, goddess, eldin goddess
   Paths:
    - stage/F000/r0/l0/TBox/79
 Skyloft - West Cliff Goddess Chest:
   Need: Goddess Cube on West Great Tree near exit
   original item: Silver Rupee
-  type: goddess
+  type: sky, goddess, faron goddess
   Paths:
    - stage/F000/r0/l0/TBox/78
 Skyloft - Floating Island Goddess Chest:
   Need: Clawshots & Goddess Cube in Lake Floria
   original item: Gold Rupee
-  type: goddess
+  type: sky, goddess, floria goddess
   Paths:
    - stage/F000/r0/l0/TBox/91
 Skyloft - Waterfall Goddess Chest:
   Need: Clawshots & Goddess Cube in Pirate Stronghold
   original item: Heart Piece
-  type: goddess
+  type: sky, goddess, sand sea goddess
   Paths:
    - stage/F000/r0/l0/TBox/80
 Skyloft - Pumpkin Archery - 600 Points:
   Need: Bow
   original item: Heart Piece
-  type: minigame
+  type: sky, minigame
   Paths:
    - event/114-Friend/99
    - oarc/F000/l4
@@ -98,19 +98,19 @@ Skyloft - Pumpkin Archery - 600 Points:
 Skyloft - Zelda Heartpiece:
   Need: Clawshots
   original item: Heart Piece
-  type: overworld
+  type: sky, miscellaneous
   Paths:
    - stage/F001r/r6/l0/chest/32 #sceneflag
 Skyloft - Baby Rattle:
   Need: Gust Bellows & Clawshots #needs work, note that it's possible to get there from Beetle's airship
   original item: Baby's Rattle
-  type: overworld
+  type: sky, freestanding
   Paths:
     - stage/F000/r0/l0/Item/13
 Skyloft - Parrow's Bottle:
   Need: Nothing
   original item: Bottle
-  type: sidequest
+  type: sky, free gift, short
   Paths:
     - event/115-Town2/230 # mushroom spores
     - event/115-Town2/733 # Bottle
@@ -119,21 +119,21 @@ Skyloft - Parrow's Bottle:
 Skyloft - Cawlin's Letter:
   Need: Goddess Harp
   original item: Cawlin's Letter
-  type: sidequest
+  type: sky, short
   Paths:
     - event/115-Town2/166
     - oarc/F001r/l0
 Skyloft - Wyrna Crystals:
   Need: Nothing
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: sky, free gift, crystal quest
   Paths:
     - event/118-Town3/144
     - oarc/F006r/l0
 Skyloft - Peater/Peatrice Crystals:
   Need: Nothing
   original item: 5 Gratitude Crystals
-  type: peatrice
+  type: sky, long, crystal quest
   Paths:
     - event/109-TakeGoron/79
     - event/123-Town5/316
@@ -143,7 +143,7 @@ Skyloft - Parrow Crystals:
   Need: Bottle
     # There are mushrooms in the Sky inside the Volcanic Island
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: sky, short, crystal quest
   Paths:
     - event/115-Town2/814
     - oarc/F000/l0
@@ -151,21 +151,21 @@ Skyloft - Parrow Crystals:
 Skyloft - Fledge Crystals:
   Need: Can Beat Lanayru Mining Facility & Bottle # LMF only for Potion right now
   original item: 5 Gratitude Crystals
-  type: sidequest, dungeon
+  type: sky, short, crystal quest, dungeon
   Paths:
     - event/115-Town2/325
     - oarc/F001r/l0
 Skyloft - Baby Crystals:
   Need: Baby Rattle
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: sky, fetch, crystal quest
   Paths:
     - event/115-Town2/125
     - oarc/F014r/l0
 Skyloft - Ghost/Pipit Crystals:
   Need: Cawlin's Letter
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: sky, fetch, crystal quest
   Paths:
     - event/115-Town2/522
     - event/115-Town2/641
@@ -173,21 +173,21 @@ Skyloft - Ghost/Pipit Crystals:
 Skyloft - Sparrot Crystals:
   Need: Can Access Second Part of Eldin & Clawshots
   original item: 5 Gratitude Crystals
-  type: scrapper
+  type: sky, long, scrapper, crystal quest
   Paths:
     - event/118-Town3/141
     - oarc/F013r/l0
 Skyloft - Cleaning Crystals:
   Need: Gust Bellows
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: sky, short, crystal quest
   Paths:
     - event/123-Town5/186
     - oarc/F016r/l0
 Skyloft - Owlan Crystals:
   Need: Can Access Most of Faron Woods & Bomb Bag
   original item: 5 Gratitude Crystals
-  type: scrapper
+  type: sky, long, scrapper, crystal quest
   Paths:
     - event/118-Town3/157
     - oarc/F001r/l0
@@ -196,62 +196,62 @@ Skyloft - Owlan Crystals:
 Skyloft - Batreaux 5 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & (5 Gratitude Crystals | Gratitude Crystal x5) # since 5 packs are randomized, it's possible to get crystals without being able to meet batreaux
   original item: Progressive Wallet
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/21
     - oarc/F012r/l0
 Skyloft - Batreaux 10 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 10 Gratitude Crystals
   original item: Heart Piece
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/42
     - oarc/F012r/l0
 Skyloft - Batreaux 30 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 30 Gratitude Crystals # 30 gratitude Crystals
   original item: Progressive Wallet
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/24
     - oarc/F012r/l0
 Skyloft - Batreaux 30 Crystals Chest:
   Need: Can Open Batreaux Shed & 30 Gratitude Crystals # 30 gratitude Crystals
   original item: Cursed Medal
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - stage/F012r/r0/l0/TBox/69
 Skyloft - Batreaux 40 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 40 Gratitude Crystals # 40 gratitude Crystals
   original item: Gold Rupee
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/49
     - oarc/F012r/l0
 Skyloft - Batreaux 50 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 50 Gratitude Crystals # 50 gratitude Crystals
   original item: Progressive Wallet
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/27
     - oarc/F012r/l0
 Skyloft - Batreaux 70 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 70 Gratitude Crystals # 70 gratitude Crystals
   original item: Gold Rupee
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/161
     - oarc/F012r/l0
 Skyloft - Batreaux 70 Crystals Second Reward:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 70 Gratitude Crystals # 70 gratitude Crystals
   original item: Gold Rupee
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/163
     - oarc/F012r/l0
 Skyloft - Batreaux 80 Crystals:
   Need: Can Open Batreaux Shed & Can Get Gratitude Crystals & 80 Gratitude Crystals # 80 gratitude Crystals
   original item: Progressive Wallet
-  type: batreaux
+  type: sky, batreaux
   Paths:
     - event/121-AkumaKun/37
     - oarc/F012r/l0
@@ -297,10 +297,6 @@ Skyloft - Crystal in Sparring Hall:
   Need: Can Get Gratitude Crystals & Beetle
   original item: Gratitude Crystal
   type: crystal
-Skyloft - Crystal on Beedles Ship:
-  Need: Can Get Gratitude Crystals & Beetle #You can access Beedle's shop with Beetle
-  original item: Gratitude Crystal
-  type: crystal
 Skyloft - Crystal on Waterfall Island:
   Need: Can Get Gratitude Crystals & Clawshots #tough beetle works too
   original item: Gratitude Crystal
@@ -313,25 +309,25 @@ Skyloft - Crystal in Zelda's Room:
 Sky - Lumpy Pumpkin Chandellier:
   Need: Nothing
   original item: Heart Piece
-  type: overworld
+  type: sky, freestanding
   Paths:
    - stage/F011r/r0/l0/Chandel
 Sky - Lumpy Pumpkin Roof Goddess Chest:
   Need: Goddess Cube in Skyview Spring
   original item: Gold Rupee
-  type: goddess, dungeon
+  type: sky, goddess, faron goddess, dungeon
   Paths:
    - stage/F020/r0/l0/TBox/87
 Sky - Lumpy Pumpkin Goddess Chest:
   Need: Initial Goddess Cube
   original item: Progressive Pouch
-  type: goddess
+  type: sky, goddess, faron goddess
   Paths:
    - stage/F020/r0/l0/TBox/64
 Sky - Lumpy Pumpkin Harp Minigame:
   Need: Goddess Harp & Bottle
   original item: Heart Piece
-  type: minigame
+  type: sky, long, minigame
   Paths:
    - event/117-Pumpkin/305
    - oarc/F011r/l0
@@ -339,100 +335,100 @@ Sky - Lumpy Pumpkin Harp Minigame:
 Sky - Bamboo Island Goddess Chest:
   Need: Goddess Cube West of Temple Entrance
   original item: Gold Rupee
-  type: goddess
+  type: sky, goddess, eldin goddess, bombable
   Paths:
    - stage/F020/r0/l0/TBox/82
 Sky - Goddess Chest on Island next to Bamboo Island:
   Need: Goddess Cube near Mogma Turf Entrance
   original item: Silver Rupee
-  type: goddess
+  type: sky, goddess, eldin goddess
   Paths:
    - stage/F020/r0/l0/TBox/71
 Sky - Goddess Chest in Cave on Island Next to Bamboo Island:
   Need: Water Scale & Goddess Cube in secret passageway in Desert
   original item: Heart Medal
-  type: goddess
+  type: sky, goddess, lanayru goddess, bombable
   Paths:
    - stage/F020/r0/l0/TBox/83
 Sky - Beedle's Island Goddess Chest:
   Need: Goddess Cube at ride in ToT area
   original item: Heart Piece
-  type: goddess
+  type: sky, goddess, lanayru goddess
   Paths:
    - stage/F020/r0/l0/TBox/89
 Sky - Beedle's Island Cage Goddess Chest:
   Need: Can Access Beedle's Shop & Goddess Cube on top of Skyview
   #Getting this chest during the day is possible but rather difficult, shouldn't be in logic
   original item: Rupee Medal
-  type: goddess
+  type: sky, goddess, faron goddess
   Paths:
    - stage/F020/r0/l0/TBox/81
 Sky - Northeast Island Goddess Cube Behind Bombable Rocks:
   Need: Bomb Bag & Goddess Cube at Lanayru Mine Entrance
   original item: Silver Rupee
-  type: goddess
+  type: sky, goddess, lanayru goddess
   Paths:
    - stage/F020/r0/l0/TBox/72
 Sky - Northeast Island Cage Goddess Cube:
   Need: Goddess Cube East of Temple Entrance
   original item: Treasure Medal
-  type: goddess
+  type: sky, goddess, eldin goddess
   Paths:
    - stage/F020/r0/l0/TBox/74
 Sky - Goddess Chest on Island Closest to Faron Pillar:
   Need: Goddess Cube in Deep Woods
   original item: Heart Piece
-  type: goddess
+  type: sky, goddess, faron goddess
   Paths:
    - stage/F020/r0/l0/TBox/65
 Sky - Goddess Chest Outside Volcanic Island:
   Need: Goddess Cube in Sand Oasis
   original item: Heart Medal
-  type: goddess
+  type: sky, goddess, lanayru goddess
   Paths:
    - stage/F020/r0/l0/TBox/67
 Sky - Goddess Chest Inside Volcanic Island:
   Need: Goddess Cube on East Great Tree with Clawshot Target
   #Normally you would need clawshots, but you can skip them with a good dive
   original item: Heart Piece
-  type: goddess
+  type: sky, goddess, faron goddess
   Paths:
    - stage/F020/r0/l0/TBox/68
 Sky - Goddess Chest Under Fun Fun Island:
   Need: Goddess Cube in Floria Waterfall
   original item: Gold Rupee
-  type: goddess
+  type: sky, goddess, floria goddess
   Paths:
    - stage/F020/r0/l0/TBox/86
 Sky - Southwest Triple Island Upper Goddes Chest:
   Need: Goddess Cube at Eldin Entrance
   original item: Small Seed Satchel
-  type: goddess
+  type: sky, goddess, eldin goddess
   Paths:
    - stage/F020/r0/l0/TBox/66
 Sky - Southwest Triple Island Lower Goddess Chest:
   Need: Goddess Cube near Hook Beetle Fight
   original item: Life Medal
-  type: goddess
+  type: sky, goddess, lanayru goddess
   Paths:
    - stage/F020/r0/l0/TBox/84
 Sky - Southwest Triple Island Cage Goddess Cube:
   Need: Clawshots & Goddess Cube in Skipper's Retreat
   original item: Potion Medal
-  type: goddess
+  type: sky, goddess, sand sea goddess
   Paths:
    - stage/F020/r0/l0/TBox/75
 Sky - Fun Fun Island Minigame:
   Need: Can Retrieve Party Wheel
   original item: Heart Piece
-  type: minigame, scrapper
+  type: sky, minigame, long, scrapper
   Paths:
    - event/110-DivingGame/19
    - oarc/F020/l2
 Sky - Dohdoh Crystals:
   Need: Can Retrieve Party Wheel
   original item: 5 Gratitude Crystals
-  type: scrapper
+  type: sky, long, scrapper
   Paths:
     - event/110-DivingGame/60
     - oarc/F020/l0
@@ -440,21 +436,21 @@ Sky - Orrielle Crystals:
   Need: Bottle
   # Need access to Faron to be able to get mushroom spores as many times as you want
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: short, crystal quest
   Paths:
     - event/115-Town2/225
     - oarc/F020/l0
 Sky - Kina Crystals:
   Need: Bottle & Goddess Harp & Can Access Eldin
   original item: 5 Gratitude Crystals
-  type: scrapper, minigame
+  type: sky, scrapper, minigame, long, crystal quest
   Paths:
     - event/117-Pumpkin/386
     - oarc/F020/l0
 Sky - Beedle's Crystals:
   Need: Can Access Beedle's Shop & Horned Colossus Beetle
   original item: 5 Gratitude Crystals
-  type: sidequest
+  type: sky, fetch, crystal quest
   Paths:
    - event/105-Terry/115
    - oarc/F020/l0
@@ -463,13 +459,13 @@ Sky - Beedle's Crystals:
 Sky - Breakable Boulder near Fun Fun island:
   Need: Spiral Charge
   original item: Silver Rupee
-  type: overworld
+  type: sky, spiral charge
   Paths:
     - stage/F020/r0/l0/TBox/70
 Sky - Breakable Boulder near Lumpy Pumpkin:
   Need: Spiral Charge
   original item: Silver Rupee
-  type: overworld
+  type: sky, spiral charge
   Paths:
     - stage/F020/r0/l0/TBox/69
 
@@ -481,79 +477,83 @@ Sky - Crystal inside Lumpy Pumpkin:
   Need: Can Get Gratitude Crystals
   original item: Gratitude Crystal
   type: crystal
+Sky - Crystal on Beedles Ship:
+  Need: Can Get Gratitude Crystals & Beetle #You can access Beedle's shop with Beetle
+  original item: Gratitude Crystal
+  type: crystal
 
 Thunderhead - Goddess Chest Outside Isle of Song:
   Need: Can Access Thunderhead & Goddess Cube in Mogma Turf
   original item: Gold Rupee
-  type: goddess
+  type: thunderhead, goddess, eldin goddess
   Paths:
    - stage/F023/r0/l0/TBox/92
 Thunderhead - Goddess Chest on top of Isle of Song:
   Need: Can Access Thunderhead & Goddess Cube near FS Entrance
   original item: Small Bomb Bag
-  type: goddess
+  type: goddess, summit goddess
   Paths:
    - stage/F023/r0/l0/TBox/85
 Thunderhead - East Island Goddess Chest:
   Need: Can Access Thunderhead & Goddess Cube on East Great Tree with Rope
   original item: Rupee Medal
-  type: goddess
+  type: thunderhead, goddess, faron goddess
   Paths:
    - stage/F023/r0/l0/TBox/73
 Thunderhead - East Island Chest:
   Need: Can Access Thunderhead
   original item: Evil Crystal
-  type: overworld
+  type: thunderhead, miscellaneous
   Paths:
    - stage/F023/r0/l0/TBox/94
 Thunderhead - Bug Island Goddess Chest:
   Need: Can Access Thunderhead & Goddess Cube in Summit Waterfall
   original item: Heart Piece
-  type: goddess
+  type: thunderhead, goddess, summit goddess
   Paths:
    - stage/F023/r0/l0/TBox/88
 Thunderhead - First Goddess Chest on Mogma Mitts Island:
   Need: Can Access Thunderhead & Mogma Mitts & Goddess Cube inside Volcano Summit
   original item: Bottle
-  type: goddess
+  type: thunderhead, goddess, summit goddess
   Paths:
    - stage/F023/r0/l0/TBox/77
 #Thunderhead - Mogma Mitts Island Quiver:
 #  Need: Can Access Thunderhead & Mogma Mitts & Goddess Cube in Lanayru Gorge
 #  original item: Small Quiver
-#  type: goddess
+#  type: thunderhead, goddess, goddess lanayru TODO: decide if this is a Lanyru or Sand Sea cube
 #  Paths:
 #   - stage/F023/r0/l0/TBox/76
 Thunderhead - Bug Island minigame:
   Need: Can Access Thunderhead & Bug Net
   original item: Horned Colossus Beetle
-  type: minigame
+  type: thunderhead, minigame
   Paths:
    - event/116-InsectGame/69
    - oarc/F023/l0
 Thunderhead - Levias:
   Need: Can Access Thunderhead & Spiral Charge & Practice Sword
   original item: Song of the Hero
-  type: scrapper
+  type: thunderhead, scrapper, combat, song
   Paths:
    - event/120-Nushi/give item after levias
    - oarc/F023/l0
 Thunderhead - Farore's Courage:
   Need: Can Access Thunderhead & Goddess Sword
   original item: Farore's Courage
-  type: overworld
+  type: thunderhead, song
   Paths:
    - stage/F010r/r0/l0/TBox/78
 Thunderhead - Nayru's Wisdom:
   Need: Can Access Thunderhead & Goddess Longsword
   original item: Nayru's Wisdom
-  type: overworld
+  type: thunderhead, song
   Paths:
    - stage/F010r/r0/l0/TBox/79
 Thunderhead - Din's Power:
   Need: Can Access Thunderhead & Goddess White Sword
   original item: Din's Power
-  type: overworld
+  type: thunderhead, song
   Paths:
    - stage/F010r/r0/l0/TBox/80
 
@@ -561,13 +561,13 @@ Thunderhead - Din's Power:
 Sealed Grounds - Inside Sealed Temple:
   Need: Can Access Sealed Temple
   original item: Revitalizing Potion
-  type: overworld
+  type: faron, miscellaneous
   Paths:
    - stage/F402/r2/l0/TBox/64
 Sealed Grounds - Ballad of the Goddess:
   Need: Can Access Sealed Temple & Goddess Harp
   original item: Ballad of the Goddess
-  type: quest
+  type: faron, song
   Paths:
    - event/501-Inpa/267
    - oarc/F402/l2
@@ -575,7 +575,7 @@ Sealed Grounds - Gorko Goddess Wall Reward:
   Need: Can Access Sealed Temple
         & Can Unlock Goddess Walls
         & Goddess Sword
-  type: quest, dungeon
+  type: faron, long, dungeon
   original item: Heart Piece
   Paths:
    - event/503-Goron/630
@@ -587,14 +587,14 @@ Sealed Grounds - Gorko Goddess Wall Reward:
 #        & Bomb Bag
 #        & Can Access Levias
 #  original item: Gold Rupee
-#  type: quest, dungeon
+#  type: faron, long, dungeon
 #  Paths:
 #   - event/503-Goron/418
 #   - oarc/F400/l0
 Sealed Grounds - True Master Sword:
   Need: Can Access Sealed Temple & Can Access Past
   original item: Progressive Sword
-  type: quest
+  type: faron #TODO: this may need to be revisited as it doesnt really fit any other checks
   Paths:
    - event/502-CenterFieldBack/17
    - oarc/F404/l1
@@ -603,70 +603,70 @@ Sealed Grounds - True Master Sword:
 Faron Woods - Heart Piece on Tree:
   Need: Can Access Most of Faron Woods
   original item: Heart Piece
-  type: overworld
+  type: faron, freestanding
   Paths:
     - stage/F100/r0/l0/Item/68
 Faron Woods - Slingshot:
   Need: Can Access Most of Faron Woods & Can Defeat Bokoblins
   original item: Slingshot
-  type: quest
+  type: faron, long, combat #because of the Lopsa Bokoblin fight, this is a combat reward
   Paths:
    - event/200-Forest/595
    - oarc/F100/l0
 Faron Woods - Deep Woods Chest:
   Need: Can Access Deep Woods
   original item: Red Rupee
-  type: overworld
+  type: faron, miscellaneous
   Paths:
    - stage/F101/r0/l0/TBox/74
 Faron Woods - Heart Piece Behind Boulder:
   Need: Can Access Most of Faron Woods & Bomb Bag
   original item: Heart Piece
-  type: overworld
+  type: faron, freestanding, bombable
   Paths:
    - stage/F100/r0/l0/Item/33 #last thing is SceneflagID
 Faron Woods - Behind Bombable Rocks near Erla:
   Need: Can Access Most of Faron Woods & Bomb Bag
   original item: Semi Rare Treasure
-  type: overworld
+  type: faron, bombable
   Paths:
    - stage/F100/r0/l0/TBox/64
 Faron Woods - Chest Inside Great Tree:
   Need: Can Access Most of Faron Woods & ((Gust Bellows & Water Scale) | (Clawshots & Can Defeat Moblins))
   #You can jump to the chest from above AFTER you defeat the Moblin to remove the void
   original item: Gold Rupee
-  type: overworld
+  type: faron, miscellaneous
   Paths:
    - stage/F100_1/r0/l0/TBox/84
 
 Lake Floria - Lake Floria Chest:
   Need: Can Access Lake Floria
   original item: Goddess Plume
-  type: overworld
+  type: faron, miscellaneous
   Paths:
    - stage/F102/r3/l0/TBox/64
 #Lake Floria - Lake Floria Silver Rupee: # not sure if we want to randomize this
 #  Need: Can Access Lake Floria
 #  original item: Silver Rupee
-#  type: overworld
+#  type: faron, freestanding
 #  Paths:
 #   - stage/F102/r2/l0/Item/60
 Lake Floria - Dragon Lair First Chest:
   Need: Can Access Lake Floria
   original item: Semi Rare Treasure
-  type: overworld
+  type: faron, miscellaneous
   Paths:
    - stage/F102_2/r0/l0/TBox/85
 Lake Floria - Dragon Lair Second Chest (Scale):
   Need: Can Access Lake Floria
   original item: Silver Rupee
-  type: overworld
+  type: faron, miscellaneous
   Paths:
    - stage/F102_2/r0/l0/TBox/84
 # Lake Floria - Outside AC: # not sure if this one works for other items
 #   Need: Can Access Lake Floria & Beetle
 #   original item: Gold Rupee
-#   type: overworld
+#   type: faron, freestanding
 #   Paths:
 #    - stage/F102_1/r0/l0/Item/64
 
@@ -674,31 +674,31 @@ Lake Floria - Dragon Lair Second Chest (Scale):
 Eldin Volcano - Behind Bombable Wall in First Room:
   Need: Can Access Eldin
   original item: Red Rupee
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F200/r1/l0/TBox/72
 Eldin Volcano - After Crawlspace:
   Need: Can Access Eldin
   original item: Red Rupee
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F200/r2/l0/TBox/66
 Eldin Volcano - Behind Bombable Wall Near HP:
   Need: Can Access Eldin
   original item: Red Rupee
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F200/r2/l0/TBox/73
 Eldin Volcano - Heart Piece on Cliff:
   Need: Can Access Eldin
   original item: Heart Piece
-  type: overworld
+  type: eldin, freestanding
   Paths:
    - stage/F200/r2/l0/Item/102 #sceneflagID
 Eldin Volcano - Behind Bombable Wall Near Volcano Ascent:
   Need: Can Access Second Part of Eldin
   original item: Red Rupee
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F200/r2/l0/TBox/71
 
@@ -706,56 +706,56 @@ Eldin Volcano - Behind Bombable Wall Near Volcano Ascent:
 Eldin Volcano - Key Piece in Front of ET:
  Need: Can Access Eldin & Digging Mitts
  original item: Key Piece
- type: overworld
+ type: eldin, digging
  Paths:
   - stage/F200/r4/l1/Soil/8
 Eldin Volcano - Key Piece Below Tower:
  Need: Can Access Eldin & Digging Mitts
  original item: Key Piece
- type: overworld
+ type: eldin, bombable, digging
  Paths:
   - stage/F200/r4/l1/Soil/9
 Eldin Volcano - Key Piece Behind Boulder on Sandy Slope:
  Need: Can Access Eldin & Digging Mitts
  original item: Key Piece
- type: overworld
+ type: eldin, bombable, digging
  Paths:
   - stage/F200/r4/l1/Soil/12
 Eldin Volcano - Key Piece After Vents:
  Need: Can Access Eldin & Digging Mitts
  original item: Key Piece
- type: overworld
+ type: eldin, digging
  Paths:
   - stage/F200/r6/l1/Soil/10
 Eldin Volcano - Key Piece After Draining Lava:
  Need: Can Access Eldin & Digging Mitts
  original item: Key Piece
- type: overworld
+ type: eldin, digging
  Paths:
   - stage/F200/r2/l1/Soil/64
 
 Mogma Turf - Free Fall chest:
   Need: Can Access Eldin
   original item: Eldin Ore
-  type: overworld
+  type: eldin, miscellaneous
   Paths:
    - stage/F210/r0/l0/TBox/64
 Mogma Turf - Behind Bombable Wall at Entrance:
   Need: Can Access Eldin
   original item: Golden Skull
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F210/r0/l0/TBox/65
 Mogma Turf - Sand Slide Chest:
   Need: Can Access Eldin & Digging Mitts
   original item: Eldin Ore
-  type: overworld
+  type: eldin, miscellaneous
   Paths:
    - stage/F210/r0/l0/TBox/68
 Mogma Turf - Digging Mitts:
   Need: Can Access Eldin & Can Defeat Bokoblins
   original item: Progressive Mitts
-  type: quest
+  type: eldin, combat
   Paths:
    - event/300-Mountain/6
    - event/300-Mountain/135
@@ -763,20 +763,20 @@ Mogma Turf - Digging Mitts:
 Mogma Turf - Behind Bombable Wall in Lava Maze:
   Need: Can Access Eldin & Digging Mitts
   original item: Silver Rupee
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F210/r0/l0/TBox/70
 
 Volcano Summit - Heart Piece Behind Digging:
   Need: Can Access Volcano Summit & Bottle & Mogma Mitts
   original item: Heart Piece
-  type: overworld
+  type: eldin, freestanding
   Paths:
    - stage/F201_3/r0/l0/Item/104 #sceneflagID
 Volcano Summit - Behind Bombable Wall in Waterfall Area:
   Need: Can Access Volcano Summit & Clawshots
   original item: Silver Rupee
-  type: overworld
+  type: eldin, bombable
   Paths:
    - stage/F201_4/r0/l0/TBox/95
 #Boko Base - Small chest in front of Sword in boko base:
@@ -793,26 +793,26 @@ Volcano Summit - Behind Bombable Wall in Waterfall Area:
 Lanayru Mines - Chest Behind First Landing:
   Need: Can Access Lanayru & Clawshots
   original item: Evil Crystal
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300_1/r0/l0/TBox/64
 Lanayru Mines - Near First Timeshift Stone:
   Need: Can Access Lanayru
   # In swordless, you can roll a bomb to the stone, eventhough it's a bit far
   original item: Red Rupee
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300_1/r1/l0/TBox/65
 Lanayru Mines - Behind Statue:
   Need: Can Access Lanayru & (Bomb Bag | Hook Beetle)
   original item: Red Rupee
-  type: overworld
+  type: lanayru, bombable
   Paths:
    - stage/F300_1/r2/l0/TBox/67
 Lanayru Mines - End of Mines:
   Need: Can Access Lanayru & (Bomb Bag | Hook Beetle)
   original item: Rare Treasure
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300_1/r2/l0/TBox/66
 
@@ -820,21 +820,21 @@ Lanayru Mines - End of Mines:
 Lanayru - Chest Near Party Wheel:
   Need: Can Access Lanayru & Bomb Bag
   original item: Golden Skull
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300/r0/l0/TBox/70
 Lanayru - Chest Before Hook Beetle:
   Need: Can Access Lanayru & (Clawshots | Bomb Bag | Hook Beetle)
   #In the Mines, you need to knock down statues to make a path through the sand (brakeslide not in logic)
   original item: Tumbleweed
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300/r0/l0/TBox/84
 Lanayru - Hook Beetle:
   Need: Can Access Lanayru & (Bomb Bag | Hook Beetle)
   # You can use bomb flowers to defeat the technoblins
   original item: Progressive Beetle
-  type: quest
+  type: lanayru, combat
   Paths:
    - event/400-Desert/8
    - oarc/F300/l0
@@ -842,44 +842,44 @@ Lanayru - NE Desert Chest:
   Need: Can Access Second Part of Lanayru & Bomb Bag
   #The Tough Beetle can be used instead of Bombs
   original item: Heart Piece
-  type: overworld
+  type: lanayru, bombable
   Paths:
    - stage/F300/r0/l0/TBox/74
 Lanayru - On Top of Lanayru Mining Facility: # actually spawns on raising LMF
   Need: Can Access Dungeon Entrance In Lanayru Desert
   original item: Rare Treasure # TODO check
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300/r0/l1/TBox/83
 Lanayru - Chest Next to Trial:
   Need: Can Access Second Part of Lanayru & Clawshots
   original item: Dusk Relic
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300/r0/l0/TBox/72
 Lanayru - Chest on Platform Near Fire Node:
   Need: Can Access Lanayru & Clawshots
   original item: Red Rupee
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300/r0/l0/TBox/73
 Lanayru - Chest Near Sand Oasis:
   Need: Can Access Lanayru & Clawshots
   original item: Red Rupee
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F300/r0/l0/TBox/71
 
 Lanayru - Beginning of Lightning Node:
   Need: Can Access Second Part of Lanayru & Bomb Bag
   original item: Red Rupee
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_2/r0/l0/TBox/75
 Lanayru - Middle of Lightning Node:
   Need: Can Access Second Part of Lanayru & Bomb Bag
   original item: Blue Rupee
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_2/r0/l0/TBox/76
 Lanayru - End of Lightning Node room:
@@ -887,50 +887,50 @@ Lanayru - End of Lightning Node room:
   # Deactivate the timeshift stone with a bomb throw that lands near the timeshift stone.
   # Then stand near the stone and activate it. Place down a bomb near the timeshift stone and run to the end.
   original item: Rare Treasure # TODO check again
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_2/r0/l0/TBox/77
 Lanayru - Fire Node Shortcut Chest:
   Need: Can Access Second Part of Lanayru & Can Defeat Ampilus
   original item: Rare Treasure # TODO check again
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_3/r0/l0/TBox/79
 Lanayru - Beginning of Fire Node:
   Need: Can Access Second Part of Lanayru & Bomb Bag
   original item: Blue Rupee
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_3/r0/l0/TBox/78
 Lanayru - Middle of Fire Node:
   Need: Can Access Second Part of Lanayru & Bomb Bag
   original item: Blue Rupee
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_3/r0/l0/TBox/80
 Lanayru - Fire Node Left Chest:
   Need: Can Access Second Part of Lanayru & Bomb Bag & Hook Beetle
   original item: Golden Skull # TODO check again
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_3/r0/l0/TBox/81
 Lanayru - Fire Node Right Chest:
   Need: Can Access Second Part of Lanayru & Bomb Bag & Hook Beetle
   original item: Blue Rupee
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F300_3/r0/l0/TBox/82
 
 Lanayru Caves - Chest:
   Need: Can Access Lanayru & Clawshots
   original item: Golden Skull # TODO check again
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F303/r0/l0/TBox/127
 Lanayru Caves - Golo:
   Need: Can Access Lanayru & Clawshots
   original item: LanayruCaves Small Key
-  type: quest
+  type: lanayru, free gift
   Paths:
    - event/404-DesertF3/127
    - oarc/F303/l0
@@ -941,34 +941,34 @@ Lanayru Sand Sea - Skydive Chest at Skippers Retreat:
   # You can whip the bomb on the cactus by first slashing it to make it swing
   # You can also whip the bomb without a sword by standing very close to the cactus and whiping a few times (up to down swings)
   original item: Silver Rupee
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F301_3/r0/l0/TBox/77
 Lanayru Sand Sea - Chest After Moblin at Skippers Retreat:
   Need: Can Access Sand Sea & (Bomb Bag | Hook Beetle | Whip)
   #If you don't have the whip, you can still get past the yellow chu cave with bombs or by using the hook beetle
   original item: Red Rupee
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F301_3/r0/l0/TBox/78
 Lanayru Sand Sea - Near Shack:
   Need: Can Access Sand Sea & Whip & (Bow | Beetle | Slingshot)
   original item: Semi Rare Treasure
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F301_3/r0/l0/TBox/76
 Lanayru Sand Sea - In Skippers Shack:
   Need: Can Access Sand Sea & Whip & (Bow | Beetle | Slingshot) & Gust Bellows
   # The Boko Baba can be bypassed without killing or stunning him, but it's not in logic
   original item: Sea Chart
-  type: overworld
+  type: lanayru, miscellaneous
   Paths:
    - stage/F301_5/r0/l0/TBox/65
 Lanayru Sand Sea - Roller Coaster Minigame:
   Need: Can Access Sand Sea & Can Defeat Molderach
   # You need Gust Bellows to defeat Molderach. I assume no Sea Chart requirement for now
   original item: Heart Piece
-  type: minigame
+  type: lanayru, minigame, combat #Molderach 2 makes this a combat check
   Paths:
    - event/406-TrolleyRace/77
    - oarc/F301_4/l0
@@ -976,19 +976,19 @@ Lanayru Sand Sea - First Chest in Pirate Stronghold:
   Need: Can Access Sand Sea
   # You can run past the Beamos without killing it. You can also run past the boko baba (in logic?)
   original item: Silver Rupee
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F301_2/r4/l0/TBox/75
 Lanayru Sand Sea - Second Chest in Pirate Stronghold:
   Need: Can Access Sand Sea
   original item: Semi Rare Treasure
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F301_2/r5/l0/TBox/73
 Lanayru Sand Sea - 3rd Chest in Pirate Stronghold:
   Need: Can Access Sand Sea
   original item: Semi Rare Treasure
-  type: overworld
+  type: lanayru, mini dungeon
   Paths:
    - stage/F301_2/r6/l0/TBox/74
 
@@ -996,7 +996,7 @@ Lanayru Sand Sea - 3rd Chest in Pirate Stronghold:
 Skyview - Map Chest:
   Need: Can Access Skyview & Can Get Past the First Skyview Room & Can Hit Vines in Skyview Left Room
   original item: Skyview Map
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r2/l0/TBox/64
 Skyview - Small Key Digging Spot:
@@ -1007,14 +1007,14 @@ Skyview - Small Key Digging Spot:
   # If you had scale to get past the first room, you can't hit the switch, unless using the gust bellows on a Spume and kill it near the switch, not in logic
   # You can hit the switch to enter that room with an upwards skyward strike using a boko or a spume, not in logic
   original item: SW Small Key
-  type: dungeon
+  type: faron, dungeon, digging
   Paths:
     - stage/D100/r4/l0/Soil/15
 Skyview - Behind Two Eyes:
   Need: Can Access Skyview & Can Get Past the First Skyview Room & Can Hit High Skyview Switches & Practice Sword
   # Sword required to defeat the eyes
   original item: SW Small Key
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r4/l0/TBox/67
 Skyview - Beetle:
@@ -1023,7 +1023,7 @@ Skyview - Beetle:
   #The fight requires sword, but can be skipped with Water Scale
   #Note that to get past the locked door you need to be able to raise the water lever once (left room is easiest)
   original item: Progressive Beetle
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r10/l1/TBox/65
    - stage/D100/r10/l2/TBox/65
@@ -1031,13 +1031,13 @@ Skyview - Behind Bars in Hub Room:
   Need: Can Access Skyview & Can Get Past the First Skyview Room & Beetle & SW Small Key x1
   #add whip when all items are fixed. In that case make also sure you can raise the water level to unlock the door
   original item: Heart Piece
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r5/l0/Item/103
 Skyview - Behind Three Eyes:
   Need: Can Access Skyview & Can Get Past the First Skyview Room & Beetle & SW Small Key x1 & Practice Sword
   original item: SW Small Key
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r7/l0/TBox/68
 Skyview - Near Boss Door:
@@ -1047,7 +1047,7 @@ Skyview - Near Boss Door:
   # The Skulltula jump is not in logic. A bomb knocks it away. Both the Beetle and the bow can cut it down. The water scale makes it Skyview 2 where there is no spider anymore. A skyward strike can knock it away too
   # The archer bokoblin can be killed with a skyward strike on Hero Mode. Otherwise you need bow or hook beetle
   original item: Red Rupee
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r9/l0/TBox/70
 Skyview - Boss Key:
@@ -1055,14 +1055,14 @@ Skyview - Boss Key:
   #Note: You can also hit this vine with a Skyward Strike, but only on Hero Mode
   Need: Can Access Skyview & Can Get Past the First Skyview Room & (Goddess Sword | Bomb Bag | Beetle | Bow | Water Scale) & ((Goddess Sword & Option "hero-mode" Enabled) | Hook Beetle | Bow | True Master Sword) & SW Small Key x2
   original item: Skyview Boss Key
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D100/r9/l0/TBox/66
 
 Skyview - Ghirahim Heart Container:
  Need: Can Access Skyview & Can Get Past the First Skyview Room & (Goddess Sword | Bomb Bag | Beetle | Bow | Water Scale) & ((Goddess Sword & Option "hero-mode" Enabled) | Hook Beetle | Bow | True Master Sword) & Practice Sword & SW Small Key x2 & SW Boss Key
  original item: Heart Container
- type: dungeon
+ type: faron, dungeon
  Paths:
   - stage/B100/r0/l1/HeartCo
   - stage/B100/r0/l2/HeartCo
@@ -1072,7 +1072,7 @@ Skyview - Ghirahim Heart Container:
 Skyview - Ruby Tablet:
   Need: Can Access Skyview & Can Get Past the First Skyview Room & Goddess Sword & (Option "hero-mode" Enabled | Hook Beetle | Bow | True Master Sword) & SW Small Key x2 & SW Boss Key
   original item: Ruby Tablet
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - event/201-ForestD1/6
    - oarc/B100_1/l0
@@ -1081,37 +1081,37 @@ Skyview - Ruby Tablet:
 Earth Temple - First Chest:
   Need: Can Access Earth Temple & Digging Mitts
   original item: Red Rupee
-  type: dungeon
+  type: eldin, dungeon, digging
   Paths:
    - stage/D200/r1/l0/TBox/66
 Earth Temple - Behind Boulder:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge
   original item: Golden Skull
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D200/r1/l0/TBox/69
 Earth Temple - Left Chest After Boulder Section:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge
   original item: Golden Skull # TODO check again
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D200/r1/l0/TBox/70
 Earth Temple - Map Chest:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge & (Bomb Bag | Hook Beetle)
   original item: ET Map
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D200/r0/l0/TBox/64
 Earth Temple - Bomb Bag:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge & Can Defeat Lezalfos
   original item: Bomb Bag
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D200/r3/l0/TBox/65
 Earth Temple - 5 Bombs From Ledd:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge & Can Defeat Lezalfos
   original item: 5 Bombs
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - event/301-MountainD1/16
    - oarc/D200/l0
@@ -1119,14 +1119,14 @@ Earth Temple - Chest Guarded by Lizalfos:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge & (Hook Beetle | (Bomb Bag & Beetle))
   #In this dungeon, the hook Beetle can replace the bombs everywhere. You absolutely need a Beetle to cut a rope in the boulder section
   original item: Red Rupee
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D200/r1/l0/TBox/67
 Earth Temple - Boss Key:
   Need: Can Access Earth Temple & Can Get Past First ET Drawbridge & (Hook Beetle | (Bomb Bag & Beetle & Digging Mitts))
   #Stutter Sprint not in logic, you need to dig up an air vent to blow up the boulder
   original item: ET Boss Key
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D200/r4/l0/TBox/68
 
@@ -1134,7 +1134,7 @@ Earth Temple - Scaldera Heart Container:
  Need: Can Access Earth Temple & Bomb Bag & (Hook Beetle | (Beetle & Digging Mitts)) & ET Boss Key & Practice Sword
  #Scaldera can be beaten without bombs but the logic does not require it
  original item: Heart Container
- type: dungeon
+ type: eldin, dungeon
  Paths:
   - stage/B200/r10/l1/HeartCo
   - stage/B200/r10/l2/HeartCo
@@ -1142,7 +1142,7 @@ Earth Temple - Scaldera Heart Container:
 Earth Temple - Amber Tablet:
   Need: Can Access Earth Temple & Bomb Bag & (Hook Beetle | (Beetle & Digging Mitts)) & ET Boss Key & Goddess Sword
   original item: Amber Tablet
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - event/301-MountainD1/22
    - oarc/B210/l0
@@ -1151,7 +1151,7 @@ Earth Temple - Amber Tablet:
 Lanayru Mining Facility - Behind Bars:
   Need: Can Access Lanayru Mining Facility
   original item: Red Rupee
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300/r0/l0/TBox/64
 Lanayru Mining Facility - First Chest in Hub Room:
@@ -1159,7 +1159,7 @@ Lanayru Mining Facility - First Chest in Hub Room:
   #You can whip the lever in the first room, but it is not in logic
   #The path that requires a small key also need hook Beetle or bombs
   original item: LMF Small Key
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300_1/r5/l0/TBox/70
 Lanayru Mining Facility - Chest in Room Behind Locked Door:
@@ -1167,26 +1167,26 @@ Lanayru Mining Facility - Chest in Room Behind Locked Door:
   #You need to blow up a crate on top of a ladder: you need hook Beetle or bombs
   #To shoot the timeshift stone you need Beetle or bow or slingshot, but the slingshot snipe is difficult?
   original item: Red Rupee
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300/r2/l0/TBox/65
 Lanayru Mining Facility - Gust Bellows:
   Need: Can Access Lanayru Mining Facility & LMF Small Key x1 & Hook Beetle
   #You need to blow up at least one rock in the maze but the Spumes can take care of that, use the hook beetle if swordless
   original item: Gust Bellows
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300/r4/l0/TBox/68
 Lanayru Mining Facility - Inside Gust Bellows Room:
   Need: Can Access Lanayru Mining Facility & LMF Small Key x1 & Hook Beetle
   original item: Golden Skull # TODO check again
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300/r4/l0/TBox/76
 Lanayru Mining Facility - First West Room:
   Need: Can Access Lanayru Mining Facility & Hook Beetle & Gust Bellows
   original item: Golden Skull # TODO check again
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300/r3/l0/TBox/66
 Lanayru Mining Facility - Map chest:
@@ -1194,41 +1194,41 @@ Lanayru Mining Facility - Map chest:
   #You need to defeat the Beamos guarding the door to the map room, but you also need to be able to defeat the Armos, thus sword required
   #The Staldras don't need to be defeated and are surprisingly not very aggressive, letting you push the block relatively easily
   original item: LMF Map
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300/r6/l0/TBox/69
 Lanayru Mining Facility - Behind First Crawlspace:
   Need: Can Access Lanayru Mining Facility & Hook Beetle & Gust Bellows & Practice Sword & Can Hit Crystal in LMF Map Room
   original item: Golden Skull # TODO check again
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300_1/r9/l0/TBox/72
    - stage/D300/r9/l0/TBox/72
 Lanayru Mining Facility - Behind Second Crawlspace:
   Need: Can Access Lanayru Mining Facility & Hook Beetle & Gust Bellows & Practice Sword & Can Hit Crystal in LMF Map Room
   original item: Red Rupee
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300_1/r7/l0/TBox/73
 Lanayru Mining Facility - Boss Key:
   Need: Can Access Lanayru Mining Facility & Hook Beetle & Gust Bellows & Practice Sword & Can Hit Crystal in LMF Map Room & Bomb Bag
   #You can hit the crystals with your sword
   original item: LMF Boss Key
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300_1/r8/l0/TBox/71
 Lanayru Mining Facility - Chest After Boss Key Room:
   Need: Can Access Lanayru Mining Facility & Hook Beetle & Gust Bellows & Practice Sword & Can Hit Crystal in LMF Map Room & Bomb Bag
   #You can hit the crystals with your sword
   original item: Red Rupee
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D300_1/r5/l0/TBox/74
 
 Lanayru Mining Facility - LMF Heart Container:
   Need: Can Access Lanayru Mining Facility & Hook Beetle & Gust Bellows & Practice Sword & Can Hit Crystal in LMF Map Room & LMF Boss Key
   original item: Heart Container
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
   - stage/B300/r0/l1/HeartCo
   - stage/B300/r0/l3/HeartCo
@@ -1236,7 +1236,7 @@ Lanayru Mining Facility - LMF Heart Container:
 Lanayru Mining Facility - Harp:
   Need: Can Beat Lanayru Mining Facility
   original item: Goddess Harp
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - event/400-Desert/286
    - oarc/F300_4/l0
@@ -1245,45 +1245,45 @@ Ancient Cistern - Small Key Chest:
   Need: Can Access Ancient Cistern & Water Scale & Practice Sword
   # Need sword for combination lock
   original item: AC Small Key
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D101/r1/l0/TBox/67
 Ancient Cistern - Whip:
   Need: Can Access Ancient Cistern & AC Small Key x2 & (Practice Sword | Can Lower Ancient Cistern Statue)
   # Defeating the Stalmaster requires Practice Sword
   original item: Whip
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D101/r7/l0/TBox/69
 Ancient Cistern - Map Chest:
   Need: Can Access Ancient Cistern & Whip
   original item: AC Map
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D101/r0/l0/TBox/65
 Ancient Cistern - Vines Chest:
   Need: Can Access Ancient Cistern & Can Lower Ancient Cistern Statue
   original item: Red Rupee
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D101/r0/l0/TBox/66
 Ancient Cistern - Behind Waterfall:
   Need: Can Access Ancient Cistern & Water Scale & Whip
   original item: Red Rupee
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D101/r3/l0/TBox/84
 Ancient Cistern - Bokoblin:
   Need: Can Access Ancient Cistern & Water Scale & Whip & (Bow | Beetle)
   original item: AC Small Key
-  type: dungeon
+  type: faron, dungeon
   Paths:
     - stage/D101/r4/l0/EBc/0xFC00
 Ancient Cistern - Boss Key:
   Need: Can Access Ancient Cistern & Can Lower Ancient Cistern Statue & (Clawshots | Hook Beetle)
   # In the Basement you can either clawshot around the boulder, or use hook Beetle to blow it up. A very precise bomb throw also works (not in logic).
   original item: AC Boss Key
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - stage/D101/r4/l0/TBox/68
 
@@ -1291,7 +1291,7 @@ Ancient Cistern - Koloktos Heart Container:
  Need: Can Access Ancient Cistern & Whip & AC Boss Key & (AC Small Key x2 | Clawshots) & Can Defeat Koloktos
  #To reach the boss door, either you unlock the door, or you lower the statue
  original item: Heart Container
- type: dungeon
+ type: faron, dungeon
  Paths:
   - stage/B101/r0/l1/HeartCo
   - stage/B101/r0/l3/HeartCo
@@ -1299,7 +1299,7 @@ Ancient Cistern - Koloktos Heart Container:
 Ancient Cistern - Goddess Longsword:
   Need: Can Access Ancient Cistern & Whip & AC Boss Key & (AC Small Key x2 | Clawshots) & Goddess Sword
   original item: Progressive Sword
-  type: dungeon
+  type: faron, dungeon
   Paths:
    - event/202-ForestD2/give item after beating ancient cistern
    - oarc/B101_1/l0
@@ -1310,20 +1310,20 @@ Sandship - Behind Combination Lock:
   # You need a sword to get rid of the lock
   # The combination is always the same, but getting the hint requires gust bellows or turning the room into the past with bow. For newcomers, require the hint
   original item: SS Small Key
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r10/l0/TBox/69
 Sandship - Bow chest:
   Need: Can Access Sandship & SS Small Key x2 & Practice Sword
   original item: Bow
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r15/l0/TBox/72
 Sandship - Heart Piece Chest:
   Need: Can Access Sandship & Bow & Clawshots
   # Note for randomized dungeon entrances: this chest can be gotten without Clawshots with an obscure jump but then you are stuck
   original item: Heart Piece
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r0/l0/TBox/127
 Sandship - Map Chest:
@@ -1331,65 +1331,65 @@ Sandship - Map Chest:
   # Getting the past inside the Sandship requires completing the Mast, even with early bow
   # The Practice Sword or two small keys are needed in order to be able to finish the Mast sequence and not be softlocked
   original item: Sandship Map
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r3/l0/TBox/71
 Sandship - Treasure Room First Chest:
   Need: Can Access Sandship & Practice Sword & Bow & Whip
   # Sword needed for generators
   original item: Semi Rare Treasure
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r9/l0/TBox/64
 Sandship - Treasure Room Second Chest:
   Need: Can Access Sandship & Practice Sword & Bow & Whip
   original item: Silver Rupee
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r9/l0/TBox/65
 Sandship - Treasure Room Third Chest:
   Need: Can Access Sandship & Practice Sword & Bow & Whip
   original item: Semi Rare Treasure
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r9/l0/TBox/66
 Sandship - Treasure Room Fourth Chest:
   Need: Can Access Sandship & Practice Sword & Bow & Whip
   original item: Silver Rupee
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r9/l0/TBox/67
 Sandship - Treasure Room Fifth Chest:
   Need: Can Access Sandship & Practice Sword & Bow & Whip
   original item: Semi Rare Treasure
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r9/l0/TBox/68
 Sandship - Robot in Brig:
   Need: Can Access Sandship & Practice Sword & Bow & Whip
   original item: SS Small Key
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - event/401-DesertD2/14
    - oarc/D301/l4
 Sandship - Boss Key:
   Need: Can Access Sandship & SS Small Key x2 & Bow
   original item: SS Boss Key
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/D301/r14/l3/TBox/73
 Sandship - Tentalus Heart Container:
   Need: Can Access Sandship & (Practice Sword | SS Small Key x2) & Bow & SS Boss Key
   # Tentalus can be defeated exclusively with bow
   original item: Heart Container
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - stage/B301/r0/l1/HeartCo
    - stage/D301/r0/l1/HeartCo
 Sandship - Nayru's Flame:
   Need: Can Access Sandship & Goddess Sword & Bow & SS Boss Key
   original item: Progressive Sword
-  type: dungeon
+  type: lanayru, dungeon
   Paths:
    - event/401-DesertD2/45
    - oarc/B301/l1
@@ -1399,46 +1399,46 @@ Fire Sanctuary - First Room:
   Need: Can Access Fire Sanctuary & Can Hit First Water Pods & Can Defeat Bokoblins
   #little known fact, the only bokoblin you need to defeat is the blue one
   original item: FS Small Key
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201/r0/l0/TBox/64
 Fire Sanctuary - After First Outside Section:
   Need: Can Access Fire Sanctuary & Can Hit First Water Pods & Can Defeat Bokoblins & FS Small Key x1
   original item: Red Rupee
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r1/l0/TBox/74
 Fire Sanctuary - Second Small Key Chest:
   Need: Can Access Fire Sanctuary & Hook Beetle & Can Defeat Lezalfos & (Gust Bellows | Clawshots) & FS Small Key x1
   #If you don't have gust bellows you can get the chest but you are stuck inside
   original item: FS Small Key
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r5/l0/TBox/69
 Fire Sanctuary - First Chest in Water Pod Room:
   Need: Can Access Fire Sanctuary & Hook Beetle & Can Defeat Lezalfos & FS Small Key x2
   original item: Red Rupee
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r7/l0/TBox/73
 Fire Sanctuary - Second Chest in Water Pod Room:
   Need: Can Access Fire Sanctuary & Hook Beetle & Can Defeat Lezalfos & FS Small Key x2
   original item: Semi Rare Treasure
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r7/l0/TBox/72
 Fire Sanctuary - Mogma Mitts:
   Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & FS Small Key x2
   # Sword needed to grab a water pod
   original item: Progressive Mitts
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r5/l0/TBox/68
 Fire Sanctuary - Bottle:
   Need: Can Access Fire Sanctuary & Can Hit First Water Pods & Practice Sword & FS Small Key x1 & Mogma Mitts
   # Sword needed to grab a water pod
   original item: Bottle
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r6/l0/TBox/70
    - stage/D201/r6/l0/TBox/70
@@ -1446,39 +1446,39 @@ Fire Sanctuary - Map Chest:
   Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & Clawshots & FS Small Key x2 & Mogma Mitts & Gust Bellows
   #Pillar Jump is not in logic. Note that if you fall without clawshots you're stuck, need to think of a fix
   original item: FS Map
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r2/l0/TBox/65
    - stage/D201/r2/l0/TBox/65
 Fire Sanctuary - Third Small Key Chest:
   Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & Clawshots & FS Small Key x2 & Mogma Mitts & Gust Bellows & Bomb Bag
   original item: FS Small Key
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201_1/r11/l0/TBox/71
 Fire Sanctuary - Plats Chest:
   Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & FS Small Key x3 & Mogma Mitts
   original item: Heart Piece
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201/r3/l0/TBox/66
 Fire Sanctuary - Staircase Room:
   Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & Clawshots & FS Small Key x3 & Mogma Mitts
   original item: Semi Rare Treasure
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201/r9/l0/TBox/75
 Fire Sanctuary - Boss Key:
   Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & Clawshots & FS Small Key x3 & Mogma Mitts
   original item: FS Boss Key
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - stage/D201/r4/l0/TBox/67
 
 Fire Sanctuary - Ghirahim Heart Container:
  Need: Can Access Fire Sanctuary & Hook Beetle & Practice Sword & FS Small Key x3 & Mogma Mitts & FS Boss Key
  original item: Heart Container
- type: dungeon
+ type: eldin, dungeon
  Paths:
   - stage/B201/r0/l1/HeartCo
   - stage/B201/r0/l2/HeartCo
@@ -1486,7 +1486,7 @@ Fire Sanctuary - Ghirahim Heart Container:
 Fire Sanctuary - Din's Flame:
   Need: Can Access Fire Sanctuary & Hook Beetle & Goddess Sword & FS Small Key x3 & Mogma Mitts & FS Boss Key
   original item: Progressive Sword
-  type: dungeon
+  type: eldin, dungeon
   Paths:
    - event/304-MountainD2/5
    - oarc/B201_1/l0
@@ -1562,13 +1562,13 @@ Fire Sanctuary - Din's Flame:
 Skykeep - Map Chest:
   Need: Can Access Skykeep
   original item: Skykeep Map
-  type: dungeon
+  type: sky, dungeon
   Paths:
    - stage/D003_7/r0/l0/TBox/64
 Skykeep - Small Key Chest:
   Need: Can Access Skykeep & Gust Bellows & Whip & Bow & Clawshots & Practice Sword
   original item: Skykeep Small Key
-  type: dungeon
+  type: sky, dungeon
   Paths:
    - stage/D003_6/r0/l0/TBox/65
 #Skykeep - Triforce of Wisdom Event
@@ -1594,27 +1594,27 @@ Skykeep - Small Key Chest:
 Skyloft Silent Realm - Stone of Trials:
   Need: Song of the Hero & Goddess Harp
   original item: Stone of Trials
-  type: silent realm
+  type: sky, silent realm
   Paths:
    - stage/S000/r0/l2/WarpObj
 
 Faron Silent Realm - Water Scale:
   Need: Can Access Most of Faron Woods & Farore's Courage & Goddess Harp
   original item: Water Scale
-  type: silent realm
+  type: faron, silent realm
   Paths:
    - stage/S100/r0/l2/WarpObj
 
 Lanayru Silent Realm - Clawshots:
   Need: Can Access Second Part of Lanayru & Nayru's Wisdom & Goddess Harp
   original item: Clawshots
-  type: silent realm
+  type: lanayru, silent realm
   Paths:
    - stage/S300/r0/l2/WarpObj
 
 Eldin Silent Realm - Fireshield Earrings:
   Need: Can Access Second Part of Eldin & Din's Power & Goddess Harp
   original item: Fireshield Earrings
-  type: silent realm
+  type: eldin, silent realm
   Paths:
    - stage/S200/r2/l2/WarpObj

--- a/SS Rando Logic - Item Location.yaml
+++ b/SS Rando Logic - Item Location.yaml
@@ -133,7 +133,7 @@ Skyloft - Wyrna Crystals:
 Skyloft - Peater/Peatrice Crystals:
   Need: Nothing
   original item: 5 Gratitude Crystals
-  type: sky, long, crystal quest
+  type: sky, long, crystal quest, peatrice
   Paths:
     - event/109-TakeGoron/79
     - event/123-Town5/316

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -16,5 +16,5 @@ DUNGEON_NAME_TO_SHORT_DUNGEON_NAME = OrderedDict([v, k] for k, v in DUNGEON_NAME
 
 ALL_TYPES = ['sky', 'thunderhead', 'faron', 'eldin', 'lanayru', 'dungeon', 'mini dungeon',  'free gift',
              'freestanding', 'miscellaneous', 'silent realm', 'digging', 'bombable', 'combat', 'song', 'spiral charge',
-             'minigame', 'batreaux', 'crystal', 'short', 'long', 'crystal quest', 'scrapper', 'goddess', 'faron goddess', 'eldin goddess',
-             'lanayru goddess', 'floria goddess', 'summit goddess', 'sand sea goddess']
+             'minigame', 'batreaux', 'crystal', 'short', 'long', 'fetch', 'crystal quest', 'scrapper', 'goddess',
+             'faron goddess', 'eldin goddess', 'lanayru goddess', 'floria goddess', 'summit goddess', 'sand sea goddess']

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -16,5 +16,6 @@ DUNGEON_NAME_TO_SHORT_DUNGEON_NAME = OrderedDict([v, k] for k, v in DUNGEON_NAME
 
 ALL_TYPES = ['sky', 'thunderhead', 'faron', 'eldin', 'lanayru', 'dungeon', 'mini dungeon',  'free gift',
              'freestanding', 'miscellaneous', 'silent realm', 'digging', 'bombable', 'combat', 'song', 'spiral charge',
-             'minigame', 'batreaux', 'crystal', 'short', 'long', 'fetch', 'crystal quest', 'scrapper', 'goddess',
-             'faron goddess', 'eldin goddess', 'lanayru goddess', 'floria goddess', 'summit goddess', 'sand sea goddess']
+             'minigame', 'batreaux', 'crystal', 'short', 'long', 'fetch', 'crystal quest', 'scrapper', 'peatrice',
+             'goddess', 'faron goddess', 'eldin goddess', 'lanayru goddess', 'floria goddess', 'summit goddess',
+             'sand sea goddess']

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -14,7 +14,7 @@ DUNGEON_NAMES = OrderedDict([
 ])
 DUNGEON_NAME_TO_SHORT_DUNGEON_NAME = OrderedDict([v, k] for k, v in DUNGEON_NAMES.items())
 
-ALL_TYPES = ['sky', 'thunderhead', 'faron', 'eldin', 'lanayru', 'dungeon', 'mini dungeon',  'free gift',
+ALL_TYPES = ['skyloft', 'sky', 'thunderhead', 'faron', 'eldin', 'lanayru', 'dungeon', 'mini dungeon',  'free gift',
              'freestanding', 'miscellaneous', 'silent realm', 'digging', 'bombable', 'combat', 'song', 'spiral charge',
              'minigame', 'batreaux', 'crystal', 'short', 'long', 'fetch', 'crystal quest', 'scrapper', 'peatrice',
              'goddess', 'faron goddess', 'eldin goddess', 'lanayru goddess', 'floria goddess', 'summit goddess',

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -14,4 +14,8 @@ DUNGEON_NAMES = OrderedDict([
 ])
 DUNGEON_NAME_TO_SHORT_DUNGEON_NAME = OrderedDict([v, k] for k, v in DUNGEON_NAMES.items())
 
-ALL_TYPES = ['batreaux', 'crystal', 'dungeon', 'goddess', 'minigame', 'overworld', 'quest', 'sidequest', 'silent realm','peatrice','scrapper']
+# ALL_TYPES = ['batreaux', 'crystal', 'dungeon', 'goddess', 'minigame', 'overworld', 'quest', 'sidequest', 'silent realm','peatrice','scrapper']
+ALL_TYPES = ['sky', 'thunderhead', 'faron', 'eldin', 'lanayru', 'dungeon', 'mini dungeon',  'free gift',
+             'freestanding', 'miscellaneous', 'silent realm', 'digging', 'bombable', 'combat', 'song', 'spiral charge',
+             'minigame', 'batreaux', 'crystal', 'short', 'long', 'crystal quest', 'scrapper', 'goddess', 'faron goddess', 'eldin goddess',
+             'lanayru goddess', 'floira goddess', 'summit goddess', 'sand sea goddess']

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -14,8 +14,7 @@ DUNGEON_NAMES = OrderedDict([
 ])
 DUNGEON_NAME_TO_SHORT_DUNGEON_NAME = OrderedDict([v, k] for k, v in DUNGEON_NAMES.items())
 
-# ALL_TYPES = ['batreaux', 'crystal', 'dungeon', 'goddess', 'minigame', 'overworld', 'quest', 'sidequest', 'silent realm','peatrice','scrapper']
 ALL_TYPES = ['sky', 'thunderhead', 'faron', 'eldin', 'lanayru', 'dungeon', 'mini dungeon',  'free gift',
              'freestanding', 'miscellaneous', 'silent realm', 'digging', 'bombable', 'combat', 'song', 'spiral charge',
              'minigame', 'batreaux', 'crystal', 'short', 'long', 'crystal quest', 'scrapper', 'goddess', 'faron goddess', 'eldin goddess',
-             'lanayru goddess', 'floira goddess', 'summit goddess', 'sand sea goddess']
+             'lanayru goddess', 'floria goddess', 'summit goddess', 'sand sea goddess']

--- a/randogui.py
+++ b/randogui.py
@@ -71,6 +71,7 @@ class RandoGUI(QMainWindow):
                     widget.valueChanged.connect(self.update_settings)
 
         self.location_descriptions = {
+            "skyloft": "Enables progression items to appear on Skyloft",
             "sky": "Enables progression items to appear in The Sky",
             "thunderhead": "Enables progression items to appear in The Thunderhead",
             "faron": "Enables progression items to appear in the Faron Province",
@@ -133,6 +134,7 @@ class RandoGUI(QMainWindow):
         self.ui.randomize_button.clicked.connect(self.randomize)
         self.ui.permalink.textChanged.connect(self.permalink_updated)
         self.ui.seed.textChanged.connect(self.update_settings)
+        self.ui.progression_goddess.clicked.connect(self.goddess_cubes_toggled)
         self.update_ui_for_settings()
         self.set_option_description(None)
 
@@ -340,6 +342,14 @@ class RandoGUI(QMainWindow):
             print(e)
         self.update_ui_for_settings()
 
+    def goddess_cubes_toggled(self):
+        enabled = self.ui.progression_goddess.isChecked()
+        self.ui.progression_faron_goddess.setEnabled(enabled)
+        self.ui.progression_eldin_goddess.setEnabled(enabled)
+        self.ui.progression_lanayru_goddess.setEnabled(enabled)
+        self.ui.progression_floria_goddess.setEnabled(enabled)
+        self.ui.progression_summit_goddess.setEnabled(enabled)
+        self.ui.progression_sand_sea_goddess.setEnabled(enabled)
 
 def run_main_gui():
     app = QtWidgets.QApplication([])

--- a/randogui.py
+++ b/randogui.py
@@ -40,7 +40,7 @@ class RandoGUI(QMainWindow):
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
 
-        self.setWindowTitle("Skyward Sword Randomizer v"+VERSION)
+        self.setWindowTitle("Skyward Sword Randomizer v" + VERSION)
 
         self.output_folder = ""
 
@@ -71,19 +71,52 @@ class RandoGUI(QMainWindow):
                     widget.valueChanged.connect(self.update_settings)
 
         self.location_descriptions = {
+            "sky": "Enables progression items to appear in The Sky",
+            "thunderhead": "Enables progression items to appear in The Thunderhead",
+            "faron": "Enables progression items to appear in the Faron Province",
+            "eldin": "Enables progression items to appear in the Eldin Province",
+            "lanayru": "Enables progression items to appear in the Lanayru Province",
+            "dungeon": "Enables progression items to appear in dungeons",
+            "mini_dungeon": "Enables progression items to appear inside Mini Dungeons (i.e. the nodes in "
+                            "Lanayru Desert)",
+            "free_gift": "Enables progression items to appear as free gifts from NPCs (i.e. the shield from "
+                         "Professor Owlan)",
+            "freestanding": "Enables progression items to appear as freestanding items in the world "
+                            "(does not include the freestanding gratitude crystals)",
+            "miscellaneous": "Enables progression items to appear in miscellaneous locations that don't fit into "
+                             "any other category (i.e. overworld chests) ",
+            "silent_realm": "Enables progression items to appear as rewards for completing Silent Realm trials",
+            "digging": "Enables progression items to appear in digging spots in the world",
+            "bombable": "Enables progression items to appear behind bombable walls",
+            "combat": "Enables progression items to appear as rewards for combat or completing a quest involving "
+                      "combat (i.e. Digging Mitts fight, Kikwi rescue)",
+            "song": "Enables progression items to appear in place of learning songs (from Isle of Song, Ballad of the "
+                    "Goddess in Sealed Temple, Song of the Hero from Levias)",
+            "spiral_charge": "Enables progression items to appear in the chests in the sky requiring Spiral Charge to"
+                             " access",
+            "minigame": "Enables progression items to appear as rewards from winning minigames",
             "batreaux": "Enables progression items to appear as rewards from giving Gratitude Crystals to Batreaux",
             "crystal": "Enables progression items to appear as loose crystals (currently not randomized and must "
                        "always be enabled)",
-            "dungeon": "Enables progression items to appear in dungeons",
+            "short": "Enables progression items to appear as rewards for completing short quests (i.e. rescuing"
+                     " Orielle)",
+            "long": "Enables progression items to appear as rewards for completing long quests (i.e. Peatrice)",
+            "crystal_quest": "Enables progression items to appear as rewards for completing Gratitude Crystal quests",
+            "scrapper": "Enables progression items to appear as rewards for Scrapper Quests",
+
             "goddess": "Enables progression items to appear as items in Goddess Chests",
-            "minigame": "Enables progression items to appear as rewards from winning minigames",
-            "overworld": "Enables progression items to appear in the overworld",
-            "quest": "Enables progression items to appear as rewards from the main quest events (i.e. in place of the "
-                     "shield from Professor Owlan)",
-            "sidequest": "Enables progression items to appear as rewards from completing gratitude crystal quests",
-            "silent_realm": "Enables progression items to appear as rewards for completing Silent Realm trials",
-            "peatrice": "Enables progression items to appear as rewards for Peatrice's sidequest",
-            "scrapper": "Enables progression items to appear as rewards for Scrapper Quests"
+            "faron_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes in "
+                             "Faron Woods and Deep Woods",
+            "eldin_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes in "
+                             "the main part of Eldin Volcano and Mogma Turf",
+            "lanayru_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes "
+                               "in the main part of Lanayru Desert, Temple of Time and Lanayru Mines",
+            "floria_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes "
+                              "in Lake Floria",
+            "summit_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes "
+                              "in Volcano Summit",
+            "sand_sea_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes "
+                                "in Sand Sea",
         }
         for check_type in ALL_TYPES:
             widget = getattr(self.ui, "progression_" + check_type.replace(" ", "_"))

--- a/randogui.py
+++ b/randogui.py
@@ -86,10 +86,11 @@ class RandoGUI(QMainWindow):
             "miscellaneous": "Enables progression items to appear in miscellaneous locations that don't fit into "
                              "any other category (i.e. overworld chests) ",
             "silent_realm": "Enables progression items to appear as rewards for completing Silent Realm trials",
-            "digging": "Enables progression items to appear in digging spots in the world",
-            "bombable": "Enables progression items to appear behind bombable walls",
+            "digging": "Enables progression items to appear in digging spots in the world (does not include Mogma "
+                       "Mitts checks, such as the one in Volcano Summit or in Fire Sanctuary)",
+            "bombable": "Enables progression items to appear behind bombable walls or other bombable structures",
             "combat": "Enables progression items to appear as rewards for combat or completing a quest involving "
-                      "combat (i.e. Digging Mitts fight, Kikwi rescue)",
+                      "combat (i.e. Digging Mitts fight, Kikwi rescue). Does not impact combat within dungeons",
             "song": "Enables progression items to appear in place of learning songs (from Isle of Song, Ballad of the "
                     "Goddess in Sealed Temple, Song of the Hero from Levias)",
             "spiral_charge": "Enables progression items to appear in the chests in the sky requiring Spiral Charge to"

--- a/randogui.py
+++ b/randogui.py
@@ -105,6 +105,7 @@ class RandoGUI(QMainWindow):
             "fetch": "Enables progression items to appear as rewards for returning items to NPCs ",
             "crystal_quest": "Enables progression items to appear as rewards for completing Gratitude Crystal quests",
             "scrapper": "Enables progression items to appear as rewards for Scrapper Quests",
+            "peatrice": "Enables a progression item to appear as the reward for completing the Peatrice side quest",
 
             "goddess": "Enables progression items to appear as items in Goddess Chests",
             "faron_goddess": "Enables progression items to appear in the Goddess Chests linked to the Goddess Cubes in "

--- a/randogui.py
+++ b/randogui.py
@@ -101,6 +101,7 @@ class RandoGUI(QMainWindow):
             "short": "Enables progression items to appear as rewards for completing short quests (i.e. rescuing"
                      " Orielle)",
             "long": "Enables progression items to appear as rewards for completing long quests (i.e. Peatrice)",
+            "fetch": "Enables progression items to appear as rewards for returning items to NPCs ",
             "crystal_quest": "Enables progression items to appear as rewards for completing Gratitude Crystal quests",
             "scrapper": "Enables progression items to appear as rewards for Scrapper Quests",
 

--- a/randogui.ui
+++ b/randogui.ui
@@ -110,42 +110,42 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <widget class="QCheckBox" name="checkBox_13">
+       <widget class="QCheckBox" name="progression_sky">
         <property name="text">
          <string>The Sky</string>
         </property>
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QCheckBox" name="checkBox_7">
+       <widget class="QCheckBox" name="progression_short">
         <property name="text">
          <string>Short Quests</string>
         </property>
        </widget>
       </item>
       <item row="1" column="4">
-       <widget class="QCheckBox" name="checkBox_18">
+       <widget class="QCheckBox" name="progression_miscellaneous">
         <property name="text">
          <string>Miscellaneous</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QCheckBox" name="checkBox_11">
+       <widget class="QCheckBox" name="progression_free_gift">
         <property name="text">
          <string>Free Gifts</string>
         </property>
        </widget>
       </item>
       <item row="2" column="4">
-       <widget class="QCheckBox" name="checkBox_22">
+       <widget class="QCheckBox" name="progression_song">
         <property name="text">
          <string>Songs</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QCheckBox" name="checkBox_20">
+       <widget class="QCheckBox" name="progression_mini_dungeon">
         <property name="text">
          <string>Mini Dungeons</string>
         </property>
@@ -159,56 +159,56 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QCheckBox" name="checkBox_12">
+       <widget class="QCheckBox" name="progression_freestanding">
         <property name="text">
          <string>Freestanding Items</string>
         </property>
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="QCheckBox" name="checkBox_8">
+       <widget class="QCheckBox" name="progression_long">
         <property name="text">
          <string>Long Quests</string>
         </property>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QCheckBox" name="checkBox_15">
+       <widget class="QCheckBox" name="progression_faron">
         <property name="text">
          <string>Faron</string>
         </property>
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="QCheckBox" name="checkBox_16">
+       <widget class="QCheckBox" name="progression_eldin">
         <property name="text">
          <string>Eldin</string>
         </property>
        </widget>
       </item>
       <item row="0" column="4">
-       <widget class="QCheckBox" name="checkBox_17">
+       <widget class="QCheckBox" name="progression_lanayru">
         <property name="text">
          <string>Lanayru</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QCheckBox" name="checkBox_14">
+       <widget class="QCheckBox" name="progression_thunderhead">
         <property name="text">
          <string>Thunderhead</string>
         </property>
        </widget>
       </item>
       <item row="4" column="2">
-       <widget class="QCheckBox" name="checkBox_9">
+       <widget class="QCheckBox" name="progression_crystal_quest">
         <property name="text">
          <string>Crystal Quests</string>
         </property>
        </widget>
       </item>
       <item row="4" column="3">
-       <widget class="QCheckBox" name="checkBox_10">
+       <widget class="QCheckBox" name="progression_scrapper">
         <property name="text">
          <string>Scrapper Quests</string>
         </property>
@@ -229,28 +229,28 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QCheckBox" name="checkBox_19">
+       <widget class="QCheckBox" name="progression_digging">
         <property name="text">
          <string>Digging Spots</string>
         </property>
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QCheckBox" name="checkBox_21">
+       <widget class="QCheckBox" name="progression_bombable">
         <property name="text">
          <string>Bombable Walls</string>
         </property>
        </widget>
       </item>
       <item row="2" column="3">
-       <widget class="QCheckBox" name="checkBox_23">
+       <widget class="QCheckBox" name="progression_combat">
         <property name="text">
          <string>Combat Rewards</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="checkBox_24">
+       <widget class="QCheckBox" name="progression_spiral_charge">
         <property name="text">
          <string>Spiral Charge Chests</string>
         </property>
@@ -476,7 +476,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="1" column="0">
-       <widget class="QCheckBox" name="checkBox">
+       <widget class="QCheckBox" name="progression_faron_goddess">
         <property name="text">
          <string>Faron Woods</string>
         </property>
@@ -490,35 +490,35 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QCheckBox" name="checkBox_2">
+       <widget class="QCheckBox" name="progression_eldin_goddess">
         <property name="text">
          <string>Eldin Volcano</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QCheckBox" name="checkBox_3">
+       <widget class="QCheckBox" name="progression_lanayru_goddess">
         <property name="text">
          <string>Lanayru Desert</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QCheckBox" name="checkBox_4">
+       <widget class="QCheckBox" name="progression_floria_goddess">
         <property name="text">
          <string>Lake Floria</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QCheckBox" name="checkBox_5">
+       <widget class="QCheckBox" name="progression_summit_goddess">
         <property name="text">
          <string>Volcano Summit</string>
         </property>
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QCheckBox" name="checkBox_6">
+       <widget class="QCheckBox" name="progression_sand_sea_goddess">
         <property name="text">
          <string>Sand Sea</string>
         </property>

--- a/randogui.ui
+++ b/randogui.ui
@@ -277,6 +277,13 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="4">
+       <widget class="QCheckBox" name="progression_peatrice">
+        <property name="text">
+         <string>Peatrice</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </widget>

--- a/randogui.ui
+++ b/randogui.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>952</width>
-    <height>621</height>
+    <height>654</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -91,9 +91,9 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>70</y>
+      <y>140</y>
       <width>931</width>
-      <height>191</height>
+      <height>151</height>
      </rect>
     </property>
     <property name="title">
@@ -105,17 +105,10 @@
        <x>10</x>
        <y>20</y>
        <width>911</width>
-       <height>161</height>
+       <height>121</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="progression_sky">
-        <property name="text">
-         <string>The Sky</string>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="0">
        <widget class="QCheckBox" name="progression_short">
         <property name="text">
@@ -169,34 +162,6 @@
        <widget class="QCheckBox" name="progression_long">
         <property name="text">
          <string>Long Quests</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QCheckBox" name="progression_faron">
-        <property name="text">
-         <string>Faron</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QCheckBox" name="progression_eldin">
-        <property name="text">
-         <string>Eldin</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QCheckBox" name="progression_lanayru">
-        <property name="text">
-         <string>Lanayru</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="progression_thunderhead">
-        <property name="text">
-         <string>Thunderhead</string>
         </property>
        </widget>
       </item>
@@ -291,7 +256,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>390</y>
+      <y>420</y>
       <width>931</width>
       <height>121</height>
      </rect>
@@ -387,7 +352,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>580</y>
+      <y>610</y>
       <width>931</width>
       <height>31</height>
      </rect>
@@ -436,7 +401,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>520</y>
+      <y>550</y>
       <width>931</width>
       <height>20</height>
      </rect>
@@ -449,7 +414,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>550</y>
+      <y>580</y>
       <width>931</width>
       <height>27</height>
      </rect>
@@ -471,7 +436,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>270</y>
+      <y>300</y>
       <width>931</width>
       <height>111</height>
      </rect>
@@ -535,6 +500,73 @@
        <widget class="QCheckBox" name="progression_sand_sea_goddess">
         <property name="text">
          <string>Sand Sea</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+   <widget class="QGroupBox" name="groupBox_4">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>80</y>
+      <width>931</width>
+      <height>51</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>What areas of the world should progress items appear?</string>
+    </property>
+    <widget class="QWidget" name="horizontalLayoutWidget_3">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>911</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QCheckBox" name="progression_skyloft">
+        <property name="text">
+         <string>Skyloft</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="progression_sky">
+        <property name="text">
+         <string>The Sky</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="progression_thunderhead">
+        <property name="text">
+         <string>Thunderhead</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="progression_lanayru">
+        <property name="text">
+         <string>Lanayru</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="progression_eldin">
+        <property name="text">
+         <string>Eldin</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="progression_faron">
+        <property name="text">
+         <string>Faron</string>
         </property>
        </widget>
       </item>

--- a/randogui.ui
+++ b/randogui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>956</width>
-    <height>441</height>
+    <width>952</width>
+    <height>621</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -93,7 +93,7 @@
       <x>10</x>
       <y>70</y>
       <width>931</width>
-      <height>131</height>
+      <height>191</height>
      </rect>
     </property>
     <property name="title">
@@ -105,46 +105,123 @@
        <x>10</x>
        <y>20</y>
        <width>911</width>
-       <height>101</height>
+       <height>161</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="progression_goddess">
-        <property name="text">
-         <string>Goddess Cubes/Chests</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="progression_crystal">
-        <property name="text">
-         <string>Loose Crystals</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="progression_dungeon">
-        <property name="text">
-         <string>Dungeon</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
-       <widget class="QCheckBox" name="progression_batreaux">
+       <widget class="QCheckBox" name="checkBox_13">
         <property name="text">
-         <string>Batreaux</string>
+         <string>The Sky</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QCheckBox" name="progression_quest">
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="checkBox_7">
         <property name="text">
-         <string>Main Quest</string>
+         <string>Short Quests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QCheckBox" name="checkBox_18">
+        <property name="text">
+         <string>Miscellaneous</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QCheckBox" name="checkBox_11">
+        <property name="text">
+         <string>Free Gifts</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="QCheckBox" name="checkBox_22">
+        <property name="text">
+         <string>Songs</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
+       <widget class="QCheckBox" name="checkBox_20">
+        <property name="text">
+         <string>Mini Dungeons</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="progression_silent_realm">
+        <property name="text">
+         <string>Silent Realms</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QCheckBox" name="checkBox_12">
+        <property name="text">
+         <string>Freestanding Items</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="checkBox_8">
+        <property name="text">
+         <string>Long Quests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QCheckBox" name="checkBox_15">
+        <property name="text">
+         <string>Faron</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QCheckBox" name="checkBox_16">
+        <property name="text">
+         <string>Eldin</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QCheckBox" name="checkBox_17">
+        <property name="text">
+         <string>Lanayru</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="checkBox_14">
+        <property name="text">
+         <string>Thunderhead</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QCheckBox" name="checkBox_9">
+        <property name="text">
+         <string>Crystal Quests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QCheckBox" name="checkBox_10">
+        <property name="text">
+         <string>Scrapper Quests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="progression_dungeon">
+        <property name="text">
+         <string>Dungeons</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
        <widget class="QCheckBox" name="progression_minigame">
         <property name="text">
          <string>Minigames</string>
@@ -152,23 +229,44 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QCheckBox" name="progression_overworld">
+       <widget class="QCheckBox" name="checkBox_19">
         <property name="text">
-         <string>Overworld</string>
+         <string>Digging Spots</string>
         </property>
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QCheckBox" name="progression_silent_realm">
+       <widget class="QCheckBox" name="checkBox_21">
         <property name="text">
-         <string>Silent Realms</string>
+         <string>Bombable Walls</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QCheckBox" name="progression_sidequest">
+      <item row="2" column="3">
+       <widget class="QCheckBox" name="checkBox_23">
         <property name="text">
-         <string>Sidequests</string>
+         <string>Combat Rewards</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="checkBox_24">
+        <property name="text">
+         <string>Spiral Charge Chests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="progression_batreaux">
+        <property name="text">
+         <string>Batreaux</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QCheckBox" name="progression_crystal">
+        <property name="text">
+         <string>Loose Crystals</string>
         </property>
        </widget>
       </item>
@@ -179,7 +277,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>210</y>
+      <y>390</y>
       <width>931</width>
       <height>121</height>
      </rect>
@@ -275,7 +373,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>400</y>
+      <y>580</y>
       <width>931</width>
       <height>31</height>
      </rect>
@@ -285,6 +383,13 @@
       <widget class="QCheckBox" name="option_dry_run">
        <property name="text">
         <string>Dry Run</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="option_hero_mode">
+       <property name="text">
+        <string>Hero Mode</string>
        </property>
       </widget>
      </item>
@@ -317,7 +422,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>340</y>
+      <y>520</y>
       <width>931</width>
       <height>20</height>
      </rect>
@@ -330,7 +435,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>370</y>
+      <y>550</y>
       <width>931</width>
       <height>27</height>
      </rect>
@@ -347,6 +452,80 @@
       <widget class="QLineEdit" name="permalink"/>
      </item>
     </layout>
+   </widget>
+   <widget class="QGroupBox" name="groupBox_3">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>270</y>
+      <width>931</width>
+      <height>111</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Goddess Cube Options</string>
+    </property>
+    <widget class="QWidget" name="gridLayoutWidget_4">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>911</width>
+       <height>80</height>
+      </rect>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="checkBox">
+        <property name="text">
+         <string>Faron Woods</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="progression_goddess">
+        <property name="text">
+         <string>Enabled</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="checkBox_2">
+        <property name="text">
+         <string>Eldin Volcano</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QCheckBox" name="checkBox_3">
+        <property name="text">
+         <string>Lanayru Desert</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="checkBox_4">
+        <property name="text">
+         <string>Lake Floria</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="checkBox_5">
+        <property name="text">
+         <string>Volcano Summit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="checkBox_6">
+        <property name="text">
+         <string>Sand Sea</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </widget>
   </widget>
  </widget>

--- a/randogui.ui
+++ b/randogui.ui
@@ -200,20 +200,6 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="2">
-       <widget class="QCheckBox" name="progression_crystal_quest">
-        <property name="text">
-         <string>Crystal Quests</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="3">
-       <widget class="QCheckBox" name="progression_scrapper">
-        <property name="text">
-         <string>Scrapper Quests</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="progression_dungeon">
         <property name="text">
@@ -267,6 +253,27 @@
        <widget class="QCheckBox" name="progression_crystal">
         <property name="text">
          <string>Loose Crystals</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="4">
+       <widget class="QCheckBox" name="progression_scrapper">
+        <property name="text">
+         <string>Scrapper Quests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QCheckBox" name="progression_crystal_quest">
+        <property name="text">
+         <string>Crystal Quests</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QCheckBox" name="progression_fetch">
+        <property name="text">
+         <string>Fetch Quests</string>
         </property>
        </widget>
       </item>

--- a/randogui.ui
+++ b/randogui.ui
@@ -550,9 +550,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="progression_lanayru">
+       <widget class="QCheckBox" name="progression_faron">
         <property name="text">
-         <string>Lanayru</string>
+         <string>Faron</string>
         </property>
        </widget>
       </item>
@@ -564,9 +564,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="progression_faron">
+       <widget class="QCheckBox" name="progression_lanayru">
         <property name="text">
-         <string>Faron</string>
+         <string>Lanayru</string>
         </property>
        </widget>
       </item>

--- a/ui_randogui.py
+++ b/ui_randogui.py
@@ -75,80 +75,80 @@ class Ui_MainWindow(object):
         self.gridLayout_3 = QGridLayout(self.gridLayoutWidget_3)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
         self.gridLayout_3.setContentsMargins(0, 0, 0, 0)
-        self.checkBox_13 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_13.setObjectName(u"checkBox_13")
+        self.progression_sky = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_sky.setObjectName(u"progression_sky")
 
-        self.gridLayout_3.addWidget(self.checkBox_13, 0, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_sky, 0, 0, 1, 1)
 
-        self.checkBox_7 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_7.setObjectName(u"checkBox_7")
+        self.progression_short = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_short.setObjectName(u"progression_short")
 
-        self.gridLayout_3.addWidget(self.checkBox_7, 4, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_short, 4, 0, 1, 1)
 
-        self.checkBox_18 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_18.setObjectName(u"checkBox_18")
+        self.progression_miscellaneous = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_miscellaneous.setObjectName(u"progression_miscellaneous")
 
-        self.gridLayout_3.addWidget(self.checkBox_18, 1, 4, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_miscellaneous, 1, 4, 1, 1)
 
-        self.checkBox_11 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_11.setObjectName(u"checkBox_11")
+        self.progression_free_gift = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_free_gift.setObjectName(u"progression_free_gift")
 
-        self.gridLayout_3.addWidget(self.checkBox_11, 1, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_free_gift, 1, 2, 1, 1)
 
-        self.checkBox_22 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_22.setObjectName(u"checkBox_22")
+        self.progression_song = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_song.setObjectName(u"progression_song")
 
-        self.gridLayout_3.addWidget(self.checkBox_22, 2, 4, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_song, 2, 4, 1, 1)
 
-        self.checkBox_20 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_20.setObjectName(u"checkBox_20")
+        self.progression_mini_dungeon = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_mini_dungeon.setObjectName(u"progression_mini_dungeon")
 
-        self.gridLayout_3.addWidget(self.checkBox_20, 1, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_mini_dungeon, 1, 1, 1, 1)
 
         self.progression_silent_realm = QCheckBox(self.gridLayoutWidget_3)
         self.progression_silent_realm.setObjectName(u"progression_silent_realm")
 
         self.gridLayout_3.addWidget(self.progression_silent_realm, 2, 0, 1, 1)
 
-        self.checkBox_12 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_12.setObjectName(u"checkBox_12")
+        self.progression_freestanding = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_freestanding.setObjectName(u"progression_freestanding")
 
-        self.gridLayout_3.addWidget(self.checkBox_12, 1, 3, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_freestanding, 1, 3, 1, 1)
 
-        self.checkBox_8 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_8.setObjectName(u"checkBox_8")
+        self.progression_long = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_long.setObjectName(u"progression_long")
 
-        self.gridLayout_3.addWidget(self.checkBox_8, 4, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_long, 4, 1, 1, 1)
 
-        self.checkBox_15 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_15.setObjectName(u"checkBox_15")
+        self.progression_faron = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_faron.setObjectName(u"progression_faron")
 
-        self.gridLayout_3.addWidget(self.checkBox_15, 0, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_faron, 0, 2, 1, 1)
 
-        self.checkBox_16 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_16.setObjectName(u"checkBox_16")
+        self.progression_eldin = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_eldin.setObjectName(u"progression_eldin")
 
-        self.gridLayout_3.addWidget(self.checkBox_16, 0, 3, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_eldin, 0, 3, 1, 1)
 
-        self.checkBox_17 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_17.setObjectName(u"checkBox_17")
+        self.progression_lanayru = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_lanayru.setObjectName(u"progression_lanayru")
 
-        self.gridLayout_3.addWidget(self.checkBox_17, 0, 4, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_lanayru, 0, 4, 1, 1)
 
-        self.checkBox_14 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_14.setObjectName(u"checkBox_14")
+        self.progression_thunderhead = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_thunderhead.setObjectName(u"progression_thunderhead")
 
-        self.gridLayout_3.addWidget(self.checkBox_14, 0, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_thunderhead, 0, 1, 1, 1)
 
-        self.checkBox_9 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_9.setObjectName(u"checkBox_9")
+        self.progression_crystal_quest = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_crystal_quest.setObjectName(u"progression_crystal_quest")
 
-        self.gridLayout_3.addWidget(self.checkBox_9, 4, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_crystal_quest, 4, 2, 1, 1)
 
-        self.checkBox_10 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_10.setObjectName(u"checkBox_10")
+        self.progression_scrapper = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_scrapper.setObjectName(u"progression_scrapper")
 
-        self.gridLayout_3.addWidget(self.checkBox_10, 4, 3, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_scrapper, 4, 3, 1, 1)
 
         self.progression_dungeon = QCheckBox(self.gridLayoutWidget_3)
         self.progression_dungeon.setObjectName(u"progression_dungeon")
@@ -160,25 +160,25 @@ class Ui_MainWindow(object):
 
         self.gridLayout_3.addWidget(self.progression_minigame, 3, 1, 1, 1)
 
-        self.checkBox_19 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_19.setObjectName(u"checkBox_19")
+        self.progression_digging = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_digging.setObjectName(u"progression_digging")
 
-        self.gridLayout_3.addWidget(self.checkBox_19, 2, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_digging, 2, 1, 1, 1)
 
-        self.checkBox_21 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_21.setObjectName(u"checkBox_21")
+        self.progression_bombable = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_bombable.setObjectName(u"progression_bombable")
 
-        self.gridLayout_3.addWidget(self.checkBox_21, 2, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_bombable, 2, 2, 1, 1)
 
-        self.checkBox_23 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_23.setObjectName(u"checkBox_23")
+        self.progression_combat = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_combat.setObjectName(u"progression_combat")
 
-        self.gridLayout_3.addWidget(self.checkBox_23, 2, 3, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_combat, 2, 3, 1, 1)
 
-        self.checkBox_24 = QCheckBox(self.gridLayoutWidget_3)
-        self.checkBox_24.setObjectName(u"checkBox_24")
+        self.progression_spiral_charge = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_spiral_charge.setObjectName(u"progression_spiral_charge")
 
-        self.gridLayout_3.addWidget(self.checkBox_24, 3, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_spiral_charge, 3, 0, 1, 1)
 
         self.progression_batreaux = QCheckBox(self.gridLayoutWidget_3)
         self.progression_batreaux.setObjectName(u"progression_batreaux")
@@ -302,40 +302,40 @@ class Ui_MainWindow(object):
         self.gridLayout_4 = QGridLayout(self.gridLayoutWidget_4)
         self.gridLayout_4.setObjectName(u"gridLayout_4")
         self.gridLayout_4.setContentsMargins(0, 0, 0, 0)
-        self.checkBox = QCheckBox(self.gridLayoutWidget_4)
-        self.checkBox.setObjectName(u"checkBox")
+        self.progression_faron_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_faron_goddess.setObjectName(u"progression_faron_goddess")
 
-        self.gridLayout_4.addWidget(self.checkBox, 1, 0, 1, 1)
+        self.gridLayout_4.addWidget(self.progression_faron_goddess, 1, 0, 1, 1)
 
         self.progression_goddess = QCheckBox(self.gridLayoutWidget_4)
         self.progression_goddess.setObjectName(u"progression_goddess")
 
         self.gridLayout_4.addWidget(self.progression_goddess, 0, 0, 1, 1)
 
-        self.checkBox_2 = QCheckBox(self.gridLayoutWidget_4)
-        self.checkBox_2.setObjectName(u"checkBox_2")
+        self.progression_eldin_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_eldin_goddess.setObjectName(u"progression_eldin_goddess")
 
-        self.gridLayout_4.addWidget(self.checkBox_2, 1, 1, 1, 1)
+        self.gridLayout_4.addWidget(self.progression_eldin_goddess, 1, 1, 1, 1)
 
-        self.checkBox_3 = QCheckBox(self.gridLayoutWidget_4)
-        self.checkBox_3.setObjectName(u"checkBox_3")
+        self.progression_lanayru_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_lanayru_goddess.setObjectName(u"progression_lanayru_goddess")
 
-        self.gridLayout_4.addWidget(self.checkBox_3, 1, 2, 1, 1)
+        self.gridLayout_4.addWidget(self.progression_lanayru_goddess, 1, 2, 1, 1)
 
-        self.checkBox_4 = QCheckBox(self.gridLayoutWidget_4)
-        self.checkBox_4.setObjectName(u"checkBox_4")
+        self.progression_floria_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_floria_goddess.setObjectName(u"progression_floria_goddess")
 
-        self.gridLayout_4.addWidget(self.checkBox_4, 2, 0, 1, 1)
+        self.gridLayout_4.addWidget(self.progression_floria_goddess, 2, 0, 1, 1)
 
-        self.checkBox_5 = QCheckBox(self.gridLayoutWidget_4)
-        self.checkBox_5.setObjectName(u"checkBox_5")
+        self.progression_summit_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_summit_goddess.setObjectName(u"progression_summit_goddess")
 
-        self.gridLayout_4.addWidget(self.checkBox_5, 2, 1, 1, 1)
+        self.gridLayout_4.addWidget(self.progression_summit_goddess, 2, 1, 1, 1)
 
-        self.checkBox_6 = QCheckBox(self.gridLayoutWidget_4)
-        self.checkBox_6.setObjectName(u"checkBox_6")
+        self.progression_sand_sea_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_sand_sea_goddess.setObjectName(u"progression_sand_sea_goddess")
 
-        self.gridLayout_4.addWidget(self.checkBox_6, 2, 2, 1, 1)
+        self.gridLayout_4.addWidget(self.progression_sand_sea_goddess, 2, 2, 1, 1)
 
         MainWindow.setCentralWidget(self.centralwidget)
 
@@ -357,27 +357,27 @@ class Ui_MainWindow(object):
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"Seed", None))
         self.ouput_folder_browse_button.setText(QCoreApplication.translate("MainWindow", u"Browse", None))
         self.groupBox.setTitle(QCoreApplication.translate("MainWindow", u"Where should progress items appear?", None))
-        self.checkBox_13.setText(QCoreApplication.translate("MainWindow", u"The Sky", None))
-        self.checkBox_7.setText(QCoreApplication.translate("MainWindow", u"Short Quests", None))
-        self.checkBox_18.setText(QCoreApplication.translate("MainWindow", u"Miscellaneous", None))
-        self.checkBox_11.setText(QCoreApplication.translate("MainWindow", u"Free Gifts", None))
-        self.checkBox_22.setText(QCoreApplication.translate("MainWindow", u"Songs", None))
-        self.checkBox_20.setText(QCoreApplication.translate("MainWindow", u"Mini Dungeons", None))
+        self.progression_sky.setText(QCoreApplication.translate("MainWindow", u"The Sky", None))
+        self.progression_short.setText(QCoreApplication.translate("MainWindow", u"Short Quests", None))
+        self.progression_miscellaneous.setText(QCoreApplication.translate("MainWindow", u"Miscellaneous", None))
+        self.progression_free_gift.setText(QCoreApplication.translate("MainWindow", u"Free Gifts", None))
+        self.progression_song.setText(QCoreApplication.translate("MainWindow", u"Songs", None))
+        self.progression_mini_dungeon.setText(QCoreApplication.translate("MainWindow", u"Mini Dungeons", None))
         self.progression_silent_realm.setText(QCoreApplication.translate("MainWindow", u"Silent Realms", None))
-        self.checkBox_12.setText(QCoreApplication.translate("MainWindow", u"Freestanding Items", None))
-        self.checkBox_8.setText(QCoreApplication.translate("MainWindow", u"Long Quests", None))
-        self.checkBox_15.setText(QCoreApplication.translate("MainWindow", u"Faron", None))
-        self.checkBox_16.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
-        self.checkBox_17.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
-        self.checkBox_14.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
-        self.checkBox_9.setText(QCoreApplication.translate("MainWindow", u"Crystal Quests", None))
-        self.checkBox_10.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
+        self.progression_freestanding.setText(QCoreApplication.translate("MainWindow", u"Freestanding Items", None))
+        self.progression_long.setText(QCoreApplication.translate("MainWindow", u"Long Quests", None))
+        self.progression_faron.setText(QCoreApplication.translate("MainWindow", u"Faron", None))
+        self.progression_eldin.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
+        self.progression_lanayru.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
+        self.progression_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
+        self.progression_crystal_quest.setText(QCoreApplication.translate("MainWindow", u"Crystal Quests", None))
+        self.progression_scrapper.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
         self.progression_dungeon.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
         self.progression_minigame.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
-        self.checkBox_19.setText(QCoreApplication.translate("MainWindow", u"Digging Spots", None))
-        self.checkBox_21.setText(QCoreApplication.translate("MainWindow", u"Bombable Walls", None))
-        self.checkBox_23.setText(QCoreApplication.translate("MainWindow", u"Combat Rewards", None))
-        self.checkBox_24.setText(QCoreApplication.translate("MainWindow", u"Spiral Charge Chests", None))
+        self.progression_digging.setText(QCoreApplication.translate("MainWindow", u"Digging Spots", None))
+        self.progression_bombable.setText(QCoreApplication.translate("MainWindow", u"Bombable Walls", None))
+        self.progression_combat.setText(QCoreApplication.translate("MainWindow", u"Combat Rewards", None))
+        self.progression_spiral_charge.setText(QCoreApplication.translate("MainWindow", u"Spiral Charge Chests", None))
         self.progression_batreaux.setText(QCoreApplication.translate("MainWindow", u"Batreaux", None))
         self.progression_crystal.setText(QCoreApplication.translate("MainWindow", u"Loose Crystals", None))
         self.groupBox_2.setTitle(QCoreApplication.translate("MainWindow", u"Additional Options", None))
@@ -393,12 +393,12 @@ class Ui_MainWindow(object):
         self.option_description.setText("")
         self.permalink_label.setText(QCoreApplication.translate("MainWindow", u"Permalink (copy paste to share your settings)", None))
         self.groupBox_3.setTitle(QCoreApplication.translate("MainWindow", u"Goddess Cube Options", None))
-        self.checkBox.setText(QCoreApplication.translate("MainWindow", u"Faron Woods", None))
+        self.progression_faron_goddess.setText(QCoreApplication.translate("MainWindow", u"Faron Woods", None))
         self.progression_goddess.setText(QCoreApplication.translate("MainWindow", u"Enabled", None))
-        self.checkBox_2.setText(QCoreApplication.translate("MainWindow", u"Eldin Volcano", None))
-        self.checkBox_3.setText(QCoreApplication.translate("MainWindow", u"Lanayru Desert", None))
-        self.checkBox_4.setText(QCoreApplication.translate("MainWindow", u"Lake Floria", None))
-        self.checkBox_5.setText(QCoreApplication.translate("MainWindow", u"Volcano Summit", None))
-        self.checkBox_6.setText(QCoreApplication.translate("MainWindow", u"Sand Sea", None))
+        self.progression_eldin_goddess.setText(QCoreApplication.translate("MainWindow", u"Eldin Volcano", None))
+        self.progression_lanayru_goddess.setText(QCoreApplication.translate("MainWindow", u"Lanayru Desert", None))
+        self.progression_floria_goddess.setText(QCoreApplication.translate("MainWindow", u"Lake Floria", None))
+        self.progression_summit_goddess.setText(QCoreApplication.translate("MainWindow", u"Volcano Summit", None))
+        self.progression_sand_sea_goddess.setText(QCoreApplication.translate("MainWindow", u"Sand Sea", None))
     # retranslateUi
 

--- a/ui_randogui.py
+++ b/ui_randogui.py
@@ -346,20 +346,20 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_4.addWidget(self.progression_thunderhead)
 
-        self.progression_lanayru = QCheckBox(self.horizontalLayoutWidget_3)
-        self.progression_lanayru.setObjectName(u"progression_lanayru")
+        self.progression_faron = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_faron.setObjectName(u"progression_faron")
 
-        self.horizontalLayout_4.addWidget(self.progression_lanayru)
+        self.horizontalLayout_4.addWidget(self.progression_faron)
 
         self.progression_eldin = QCheckBox(self.horizontalLayoutWidget_3)
         self.progression_eldin.setObjectName(u"progression_eldin")
 
         self.horizontalLayout_4.addWidget(self.progression_eldin)
 
-        self.progression_faron = QCheckBox(self.horizontalLayoutWidget_3)
-        self.progression_faron.setObjectName(u"progression_faron")
+        self.progression_lanayru = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_lanayru.setObjectName(u"progression_lanayru")
 
-        self.horizontalLayout_4.addWidget(self.progression_faron)
+        self.horizontalLayout_4.addWidget(self.progression_lanayru)
 
         MainWindow.setCentralWidget(self.centralwidget)
 
@@ -425,8 +425,8 @@ class Ui_MainWindow(object):
         self.progression_skyloft.setText(QCoreApplication.translate("MainWindow", u"Skyloft", None))
         self.progression_sky.setText(QCoreApplication.translate("MainWindow", u"The Sky", None))
         self.progression_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
-        self.progression_lanayru.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
-        self.progression_eldin.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
         self.progression_faron.setText(QCoreApplication.translate("MainWindow", u"Faron", None))
+        self.progression_eldin.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
+        self.progression_lanayru.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
     # retranslateUi
 

--- a/ui_randogui.py
+++ b/ui_randogui.py
@@ -17,7 +17,7 @@ class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
-        MainWindow.resize(956, 441)
+        MainWindow.resize(952, 621)
         sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -68,71 +68,131 @@ class Ui_MainWindow(object):
 
         self.groupBox = QGroupBox(self.centralwidget)
         self.groupBox.setObjectName(u"groupBox")
-        self.groupBox.setGeometry(QRect(10, 70, 931, 131))
+        self.groupBox.setGeometry(QRect(10, 70, 931, 191))
         self.gridLayoutWidget_3 = QWidget(self.groupBox)
         self.gridLayoutWidget_3.setObjectName(u"gridLayoutWidget_3")
-        self.gridLayoutWidget_3.setGeometry(QRect(10, 20, 911, 101))
+        self.gridLayoutWidget_3.setGeometry(QRect(10, 20, 911, 161))
         self.gridLayout_3 = QGridLayout(self.gridLayoutWidget_3)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
         self.gridLayout_3.setContentsMargins(0, 0, 0, 0)
-        self.progression_goddess = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_goddess.setObjectName(u"progression_goddess")
+        self.checkBox_13 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_13.setObjectName(u"checkBox_13")
 
-        self.gridLayout_3.addWidget(self.progression_goddess, 0, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_13, 0, 0, 1, 1)
 
-        self.progression_crystal = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_crystal.setObjectName(u"progression_crystal")
+        self.checkBox_7 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_7.setObjectName(u"checkBox_7")
 
-        self.gridLayout_3.addWidget(self.progression_crystal, 1, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_7, 4, 0, 1, 1)
 
-        self.progression_dungeon = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_dungeon.setObjectName(u"progression_dungeon")
+        self.checkBox_18 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_18.setObjectName(u"checkBox_18")
 
-        self.gridLayout_3.addWidget(self.progression_dungeon, 2, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_18, 1, 4, 1, 1)
 
-        self.progression_batreaux = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_batreaux.setObjectName(u"progression_batreaux")
+        self.checkBox_11 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_11.setObjectName(u"checkBox_11")
 
-        self.gridLayout_3.addWidget(self.progression_batreaux, 0, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_11, 1, 2, 1, 1)
 
-        self.progression_quest = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_quest.setObjectName(u"progression_quest")
+        self.checkBox_22 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_22.setObjectName(u"checkBox_22")
 
-        self.gridLayout_3.addWidget(self.progression_quest, 0, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_22, 2, 4, 1, 1)
 
-        self.progression_minigame = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_minigame.setObjectName(u"progression_minigame")
+        self.checkBox_20 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_20.setObjectName(u"checkBox_20")
 
-        self.gridLayout_3.addWidget(self.progression_minigame, 1, 1, 1, 1)
-
-        self.progression_overworld = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_overworld.setObjectName(u"progression_overworld")
-
-        self.gridLayout_3.addWidget(self.progression_overworld, 2, 1, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_20, 1, 1, 1, 1)
 
         self.progression_silent_realm = QCheckBox(self.gridLayoutWidget_3)
         self.progression_silent_realm.setObjectName(u"progression_silent_realm")
 
-        self.gridLayout_3.addWidget(self.progression_silent_realm, 2, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.progression_silent_realm, 2, 0, 1, 1)
 
-        self.progression_sidequest = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_sidequest.setObjectName(u"progression_sidequest")
+        self.checkBox_12 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_12.setObjectName(u"checkBox_12")
 
-        self.gridLayout_3.addWidget(self.progression_sidequest, 1, 2, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_12, 1, 3, 1, 1)
 
-        self.progression_peatrice = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_peatrice.setObjectName(u"progression_peatrice")
+        self.checkBox_8 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_8.setObjectName(u"checkBox_8")
 
-        self.gridLayout_3.addWidget(self.progression_peatrice, 1, 3, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_8, 4, 1, 1, 1)
 
-        self.progression_scrapper = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_scrapper.setObjectName(u"progression_scrapper")
+        self.checkBox_15 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_15.setObjectName(u"checkBox_15")
 
-        self.gridLayout_3.addWidget(self.progression_scrapper, 0, 3, 1, 1)
+        self.gridLayout_3.addWidget(self.checkBox_15, 0, 2, 1, 1)
+
+        self.checkBox_16 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_16.setObjectName(u"checkBox_16")
+
+        self.gridLayout_3.addWidget(self.checkBox_16, 0, 3, 1, 1)
+
+        self.checkBox_17 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_17.setObjectName(u"checkBox_17")
+
+        self.gridLayout_3.addWidget(self.checkBox_17, 0, 4, 1, 1)
+
+        self.checkBox_14 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_14.setObjectName(u"checkBox_14")
+
+        self.gridLayout_3.addWidget(self.checkBox_14, 0, 1, 1, 1)
+
+        self.checkBox_9 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_9.setObjectName(u"checkBox_9")
+
+        self.gridLayout_3.addWidget(self.checkBox_9, 4, 2, 1, 1)
+
+        self.checkBox_10 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_10.setObjectName(u"checkBox_10")
+
+        self.gridLayout_3.addWidget(self.checkBox_10, 4, 3, 1, 1)
+
+        self.progression_dungeon = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_dungeon.setObjectName(u"progression_dungeon")
+
+        self.gridLayout_3.addWidget(self.progression_dungeon, 1, 0, 1, 1)
+
+        self.progression_minigame = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_minigame.setObjectName(u"progression_minigame")
+
+        self.gridLayout_3.addWidget(self.progression_minigame, 3, 1, 1, 1)
+
+        self.checkBox_19 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_19.setObjectName(u"checkBox_19")
+
+        self.gridLayout_3.addWidget(self.checkBox_19, 2, 1, 1, 1)
+
+        self.checkBox_21 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_21.setObjectName(u"checkBox_21")
+
+        self.gridLayout_3.addWidget(self.checkBox_21, 2, 2, 1, 1)
+
+        self.checkBox_23 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_23.setObjectName(u"checkBox_23")
+
+        self.gridLayout_3.addWidget(self.checkBox_23, 2, 3, 1, 1)
+
+        self.checkBox_24 = QCheckBox(self.gridLayoutWidget_3)
+        self.checkBox_24.setObjectName(u"checkBox_24")
+
+        self.gridLayout_3.addWidget(self.checkBox_24, 3, 0, 1, 1)
+
+        self.progression_batreaux = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_batreaux.setObjectName(u"progression_batreaux")
+
+        self.gridLayout_3.addWidget(self.progression_batreaux, 3, 2, 1, 1)
+
+        self.progression_crystal = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_crystal.setObjectName(u"progression_crystal")
+
+        self.gridLayout_3.addWidget(self.progression_crystal, 3, 3, 1, 1)
 
         self.groupBox_2 = QGroupBox(self.centralwidget)
         self.groupBox_2.setObjectName(u"groupBox_2")
-        self.groupBox_2.setGeometry(QRect(10, 210, 931, 121))
+        self.groupBox_2.setGeometry(QRect(10, 390, 931, 121))
         self.gridLayoutWidget_2 = QWidget(self.groupBox_2)
         self.gridLayoutWidget_2.setObjectName(u"gridLayoutWidget_2")
         self.gridLayoutWidget_2.setGeometry(QRect(10, 20, 911, 97))
@@ -190,7 +250,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayoutWidget = QWidget(self.centralwidget)
         self.horizontalLayoutWidget.setObjectName(u"horizontalLayoutWidget")
-        self.horizontalLayoutWidget.setGeometry(QRect(10, 400, 931, 31))
+        self.horizontalLayoutWidget.setGeometry(QRect(10, 580, 931, 31))
         self.horizontalLayout = QHBoxLayout(self.horizontalLayoutWidget)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.horizontalLayout.setContentsMargins(0, 0, 0, 0)
@@ -201,7 +261,7 @@ class Ui_MainWindow(object):
 
         self.option_hero_mode = QCheckBox(self.horizontalLayoutWidget)
         self.option_hero_mode.setObjectName(u"option_hero_mode")
-        
+
         self.horizontalLayout.addWidget(self.option_hero_mode)
 
         self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
@@ -216,10 +276,10 @@ class Ui_MainWindow(object):
         self.option_description = QLabel(self.centralwidget)
         self.option_description.setObjectName(u"option_description")
         self.option_description.setEnabled(True)
-        self.option_description.setGeometry(QRect(10, 340, 931, 20))
+        self.option_description.setGeometry(QRect(10, 520, 931, 20))
         self.horizontalLayoutWidget_2 = QWidget(self.centralwidget)
         self.horizontalLayoutWidget_2.setObjectName(u"horizontalLayoutWidget_2")
-        self.horizontalLayoutWidget_2.setGeometry(QRect(10, 370, 931, 27))
+        self.horizontalLayoutWidget_2.setGeometry(QRect(10, 550, 931, 27))
         self.horizontalLayout_3 = QHBoxLayout(self.horizontalLayoutWidget_2)
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
         self.horizontalLayout_3.setContentsMargins(0, 0, 0, 0)
@@ -232,6 +292,50 @@ class Ui_MainWindow(object):
         self.permalink.setObjectName(u"permalink")
 
         self.horizontalLayout_3.addWidget(self.permalink)
+
+        self.groupBox_3 = QGroupBox(self.centralwidget)
+        self.groupBox_3.setObjectName(u"groupBox_3")
+        self.groupBox_3.setGeometry(QRect(10, 270, 931, 111))
+        self.gridLayoutWidget_4 = QWidget(self.groupBox_3)
+        self.gridLayoutWidget_4.setObjectName(u"gridLayoutWidget_4")
+        self.gridLayoutWidget_4.setGeometry(QRect(10, 20, 911, 80))
+        self.gridLayout_4 = QGridLayout(self.gridLayoutWidget_4)
+        self.gridLayout_4.setObjectName(u"gridLayout_4")
+        self.gridLayout_4.setContentsMargins(0, 0, 0, 0)
+        self.checkBox = QCheckBox(self.gridLayoutWidget_4)
+        self.checkBox.setObjectName(u"checkBox")
+
+        self.gridLayout_4.addWidget(self.checkBox, 1, 0, 1, 1)
+
+        self.progression_goddess = QCheckBox(self.gridLayoutWidget_4)
+        self.progression_goddess.setObjectName(u"progression_goddess")
+
+        self.gridLayout_4.addWidget(self.progression_goddess, 0, 0, 1, 1)
+
+        self.checkBox_2 = QCheckBox(self.gridLayoutWidget_4)
+        self.checkBox_2.setObjectName(u"checkBox_2")
+
+        self.gridLayout_4.addWidget(self.checkBox_2, 1, 1, 1, 1)
+
+        self.checkBox_3 = QCheckBox(self.gridLayoutWidget_4)
+        self.checkBox_3.setObjectName(u"checkBox_3")
+
+        self.gridLayout_4.addWidget(self.checkBox_3, 1, 2, 1, 1)
+
+        self.checkBox_4 = QCheckBox(self.gridLayoutWidget_4)
+        self.checkBox_4.setObjectName(u"checkBox_4")
+
+        self.gridLayout_4.addWidget(self.checkBox_4, 2, 0, 1, 1)
+
+        self.checkBox_5 = QCheckBox(self.gridLayoutWidget_4)
+        self.checkBox_5.setObjectName(u"checkBox_5")
+
+        self.gridLayout_4.addWidget(self.checkBox_5, 2, 1, 1, 1)
+
+        self.checkBox_6 = QCheckBox(self.gridLayoutWidget_4)
+        self.checkBox_6.setObjectName(u"checkBox_6")
+
+        self.gridLayout_4.addWidget(self.checkBox_6, 2, 2, 1, 1)
 
         MainWindow.setCentralWidget(self.centralwidget)
 
@@ -253,17 +357,29 @@ class Ui_MainWindow(object):
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"Seed", None))
         self.ouput_folder_browse_button.setText(QCoreApplication.translate("MainWindow", u"Browse", None))
         self.groupBox.setTitle(QCoreApplication.translate("MainWindow", u"Where should progress items appear?", None))
-        self.progression_goddess.setText(QCoreApplication.translate("MainWindow", u"Goddess Cubes/Chests", None))
-        self.progression_crystal.setText(QCoreApplication.translate("MainWindow", u"Loose Crystals", None))
-        self.progression_dungeon.setText(QCoreApplication.translate("MainWindow", u"Dungeon", None))
-        self.progression_batreaux.setText(QCoreApplication.translate("MainWindow", u"Batreaux", None))
-        self.progression_quest.setText(QCoreApplication.translate("MainWindow", u"Main Quest", None))
-        self.progression_minigame.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
-        self.progression_overworld.setText(QCoreApplication.translate("MainWindow", u"Overworld", None))
+        self.checkBox_13.setText(QCoreApplication.translate("MainWindow", u"The Sky", None))
+        self.checkBox_7.setText(QCoreApplication.translate("MainWindow", u"Short Quests", None))
+        self.checkBox_18.setText(QCoreApplication.translate("MainWindow", u"Miscellaneous", None))
+        self.checkBox_11.setText(QCoreApplication.translate("MainWindow", u"Free Gifts", None))
+        self.checkBox_22.setText(QCoreApplication.translate("MainWindow", u"Songs", None))
+        self.checkBox_20.setText(QCoreApplication.translate("MainWindow", u"Mini Dungeons", None))
         self.progression_silent_realm.setText(QCoreApplication.translate("MainWindow", u"Silent Realms", None))
-        self.progression_sidequest.setText(QCoreApplication.translate("MainWindow", u"Short Sidequests", None))
-        self.progression_peatrice.setText(QCoreApplication.translate("MainWindow", u"Peatrice", None))
-        self.progression_scrapper.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
+        self.checkBox_12.setText(QCoreApplication.translate("MainWindow", u"Freestanding Items", None))
+        self.checkBox_8.setText(QCoreApplication.translate("MainWindow", u"Long Quests", None))
+        self.checkBox_15.setText(QCoreApplication.translate("MainWindow", u"Faron", None))
+        self.checkBox_16.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
+        self.checkBox_17.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
+        self.checkBox_14.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
+        self.checkBox_9.setText(QCoreApplication.translate("MainWindow", u"Crystal Quests", None))
+        self.checkBox_10.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
+        self.progression_dungeon.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
+        self.progression_minigame.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
+        self.checkBox_19.setText(QCoreApplication.translate("MainWindow", u"Digging Spots", None))
+        self.checkBox_21.setText(QCoreApplication.translate("MainWindow", u"Bombable Walls", None))
+        self.checkBox_23.setText(QCoreApplication.translate("MainWindow", u"Combat Rewards", None))
+        self.checkBox_24.setText(QCoreApplication.translate("MainWindow", u"Spiral Charge Chests", None))
+        self.progression_batreaux.setText(QCoreApplication.translate("MainWindow", u"Batreaux", None))
+        self.progression_crystal.setText(QCoreApplication.translate("MainWindow", u"Loose Crystals", None))
         self.groupBox_2.setTitle(QCoreApplication.translate("MainWindow", u"Additional Options", None))
         self.option_closed_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Closed Thunderhead", None))
         self.option_swordless.setText(QCoreApplication.translate("MainWindow", u"Swordless", None))
@@ -276,5 +392,13 @@ class Ui_MainWindow(object):
         self.randomize_button.setText(QCoreApplication.translate("MainWindow", u"Randomize", None))
         self.option_description.setText("")
         self.permalink_label.setText(QCoreApplication.translate("MainWindow", u"Permalink (copy paste to share your settings)", None))
+        self.groupBox_3.setTitle(QCoreApplication.translate("MainWindow", u"Goddess Cube Options", None))
+        self.checkBox.setText(QCoreApplication.translate("MainWindow", u"Faron Woods", None))
+        self.progression_goddess.setText(QCoreApplication.translate("MainWindow", u"Enabled", None))
+        self.checkBox_2.setText(QCoreApplication.translate("MainWindow", u"Eldin Volcano", None))
+        self.checkBox_3.setText(QCoreApplication.translate("MainWindow", u"Lanayru Desert", None))
+        self.checkBox_4.setText(QCoreApplication.translate("MainWindow", u"Lake Floria", None))
+        self.checkBox_5.setText(QCoreApplication.translate("MainWindow", u"Volcano Summit", None))
+        self.checkBox_6.setText(QCoreApplication.translate("MainWindow", u"Sand Sea", None))
     # retranslateUi
 

--- a/ui_randogui.py
+++ b/ui_randogui.py
@@ -140,16 +140,6 @@ class Ui_MainWindow(object):
 
         self.gridLayout_3.addWidget(self.progression_thunderhead, 0, 1, 1, 1)
 
-        self.progression_crystal_quest = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_crystal_quest.setObjectName(u"progression_crystal_quest")
-
-        self.gridLayout_3.addWidget(self.progression_crystal_quest, 4, 2, 1, 1)
-
-        self.progression_scrapper = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_scrapper.setObjectName(u"progression_scrapper")
-
-        self.gridLayout_3.addWidget(self.progression_scrapper, 4, 3, 1, 1)
-
         self.progression_dungeon = QCheckBox(self.gridLayoutWidget_3)
         self.progression_dungeon.setObjectName(u"progression_dungeon")
 
@@ -189,6 +179,21 @@ class Ui_MainWindow(object):
         self.progression_crystal.setObjectName(u"progression_crystal")
 
         self.gridLayout_3.addWidget(self.progression_crystal, 3, 3, 1, 1)
+
+        self.progression_scrapper = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_scrapper.setObjectName(u"progression_scrapper")
+
+        self.gridLayout_3.addWidget(self.progression_scrapper, 4, 4, 1, 1)
+
+        self.progression_crystal_quest = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_crystal_quest.setObjectName(u"progression_crystal_quest")
+
+        self.gridLayout_3.addWidget(self.progression_crystal_quest, 4, 3, 1, 1)
+
+        self.progression_fetch = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_fetch.setObjectName(u"progression_fetch")
+
+        self.gridLayout_3.addWidget(self.progression_fetch, 4, 2, 1, 1)
 
         self.groupBox_2 = QGroupBox(self.centralwidget)
         self.groupBox_2.setObjectName(u"groupBox_2")
@@ -370,8 +375,6 @@ class Ui_MainWindow(object):
         self.progression_eldin.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
         self.progression_lanayru.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
         self.progression_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
-        self.progression_crystal_quest.setText(QCoreApplication.translate("MainWindow", u"Crystal Quests", None))
-        self.progression_scrapper.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
         self.progression_dungeon.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
         self.progression_minigame.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
         self.progression_digging.setText(QCoreApplication.translate("MainWindow", u"Digging Spots", None))
@@ -380,6 +383,9 @@ class Ui_MainWindow(object):
         self.progression_spiral_charge.setText(QCoreApplication.translate("MainWindow", u"Spiral Charge Chests", None))
         self.progression_batreaux.setText(QCoreApplication.translate("MainWindow", u"Batreaux", None))
         self.progression_crystal.setText(QCoreApplication.translate("MainWindow", u"Loose Crystals", None))
+        self.progression_scrapper.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
+        self.progression_crystal_quest.setText(QCoreApplication.translate("MainWindow", u"Crystal Quests", None))
+        self.progression_fetch.setText(QCoreApplication.translate("MainWindow", u"Fetch Quests", None))
         self.groupBox_2.setTitle(QCoreApplication.translate("MainWindow", u"Additional Options", None))
         self.option_closed_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Closed Thunderhead", None))
         self.option_swordless.setText(QCoreApplication.translate("MainWindow", u"Swordless", None))

--- a/ui_randogui.py
+++ b/ui_randogui.py
@@ -195,6 +195,11 @@ class Ui_MainWindow(object):
 
         self.gridLayout_3.addWidget(self.progression_fetch, 4, 2, 1, 1)
 
+        self.progression_peatrice = QCheckBox(self.gridLayoutWidget_3)
+        self.progression_peatrice.setObjectName(u"progression_peatrice")
+
+        self.gridLayout_3.addWidget(self.progression_peatrice, 3, 4, 1, 1)
+
         self.groupBox_2 = QGroupBox(self.centralwidget)
         self.groupBox_2.setObjectName(u"groupBox_2")
         self.groupBox_2.setGeometry(QRect(10, 390, 931, 121))
@@ -386,6 +391,7 @@ class Ui_MainWindow(object):
         self.progression_scrapper.setText(QCoreApplication.translate("MainWindow", u"Scrapper Quests", None))
         self.progression_crystal_quest.setText(QCoreApplication.translate("MainWindow", u"Crystal Quests", None))
         self.progression_fetch.setText(QCoreApplication.translate("MainWindow", u"Fetch Quests", None))
+        self.progression_peatrice.setText(QCoreApplication.translate("MainWindow", u"Peatrice", None))
         self.groupBox_2.setTitle(QCoreApplication.translate("MainWindow", u"Additional Options", None))
         self.option_closed_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Closed Thunderhead", None))
         self.option_swordless.setText(QCoreApplication.translate("MainWindow", u"Swordless", None))

--- a/ui_randogui.py
+++ b/ui_randogui.py
@@ -17,7 +17,7 @@ class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
-        MainWindow.resize(952, 621)
+        MainWindow.resize(952, 654)
         sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -68,18 +68,13 @@ class Ui_MainWindow(object):
 
         self.groupBox = QGroupBox(self.centralwidget)
         self.groupBox.setObjectName(u"groupBox")
-        self.groupBox.setGeometry(QRect(10, 70, 931, 191))
+        self.groupBox.setGeometry(QRect(10, 140, 931, 151))
         self.gridLayoutWidget_3 = QWidget(self.groupBox)
         self.gridLayoutWidget_3.setObjectName(u"gridLayoutWidget_3")
-        self.gridLayoutWidget_3.setGeometry(QRect(10, 20, 911, 161))
+        self.gridLayoutWidget_3.setGeometry(QRect(10, 20, 911, 121))
         self.gridLayout_3 = QGridLayout(self.gridLayoutWidget_3)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
         self.gridLayout_3.setContentsMargins(0, 0, 0, 0)
-        self.progression_sky = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_sky.setObjectName(u"progression_sky")
-
-        self.gridLayout_3.addWidget(self.progression_sky, 0, 0, 1, 1)
-
         self.progression_short = QCheckBox(self.gridLayoutWidget_3)
         self.progression_short.setObjectName(u"progression_short")
 
@@ -119,26 +114,6 @@ class Ui_MainWindow(object):
         self.progression_long.setObjectName(u"progression_long")
 
         self.gridLayout_3.addWidget(self.progression_long, 4, 1, 1, 1)
-
-        self.progression_faron = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_faron.setObjectName(u"progression_faron")
-
-        self.gridLayout_3.addWidget(self.progression_faron, 0, 2, 1, 1)
-
-        self.progression_eldin = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_eldin.setObjectName(u"progression_eldin")
-
-        self.gridLayout_3.addWidget(self.progression_eldin, 0, 3, 1, 1)
-
-        self.progression_lanayru = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_lanayru.setObjectName(u"progression_lanayru")
-
-        self.gridLayout_3.addWidget(self.progression_lanayru, 0, 4, 1, 1)
-
-        self.progression_thunderhead = QCheckBox(self.gridLayoutWidget_3)
-        self.progression_thunderhead.setObjectName(u"progression_thunderhead")
-
-        self.gridLayout_3.addWidget(self.progression_thunderhead, 0, 1, 1, 1)
 
         self.progression_dungeon = QCheckBox(self.gridLayoutWidget_3)
         self.progression_dungeon.setObjectName(u"progression_dungeon")
@@ -202,7 +177,7 @@ class Ui_MainWindow(object):
 
         self.groupBox_2 = QGroupBox(self.centralwidget)
         self.groupBox_2.setObjectName(u"groupBox_2")
-        self.groupBox_2.setGeometry(QRect(10, 390, 931, 121))
+        self.groupBox_2.setGeometry(QRect(10, 420, 931, 121))
         self.gridLayoutWidget_2 = QWidget(self.groupBox_2)
         self.gridLayoutWidget_2.setObjectName(u"gridLayoutWidget_2")
         self.gridLayoutWidget_2.setGeometry(QRect(10, 20, 911, 97))
@@ -260,7 +235,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayoutWidget = QWidget(self.centralwidget)
         self.horizontalLayoutWidget.setObjectName(u"horizontalLayoutWidget")
-        self.horizontalLayoutWidget.setGeometry(QRect(10, 580, 931, 31))
+        self.horizontalLayoutWidget.setGeometry(QRect(10, 610, 931, 31))
         self.horizontalLayout = QHBoxLayout(self.horizontalLayoutWidget)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.horizontalLayout.setContentsMargins(0, 0, 0, 0)
@@ -286,10 +261,10 @@ class Ui_MainWindow(object):
         self.option_description = QLabel(self.centralwidget)
         self.option_description.setObjectName(u"option_description")
         self.option_description.setEnabled(True)
-        self.option_description.setGeometry(QRect(10, 520, 931, 20))
+        self.option_description.setGeometry(QRect(10, 550, 931, 20))
         self.horizontalLayoutWidget_2 = QWidget(self.centralwidget)
         self.horizontalLayoutWidget_2.setObjectName(u"horizontalLayoutWidget_2")
-        self.horizontalLayoutWidget_2.setGeometry(QRect(10, 550, 931, 27))
+        self.horizontalLayoutWidget_2.setGeometry(QRect(10, 580, 931, 27))
         self.horizontalLayout_3 = QHBoxLayout(self.horizontalLayoutWidget_2)
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
         self.horizontalLayout_3.setContentsMargins(0, 0, 0, 0)
@@ -305,7 +280,7 @@ class Ui_MainWindow(object):
 
         self.groupBox_3 = QGroupBox(self.centralwidget)
         self.groupBox_3.setObjectName(u"groupBox_3")
-        self.groupBox_3.setGeometry(QRect(10, 270, 931, 111))
+        self.groupBox_3.setGeometry(QRect(10, 300, 931, 111))
         self.gridLayoutWidget_4 = QWidget(self.groupBox_3)
         self.gridLayoutWidget_4.setObjectName(u"gridLayoutWidget_4")
         self.gridLayoutWidget_4.setGeometry(QRect(10, 20, 911, 80))
@@ -347,6 +322,45 @@ class Ui_MainWindow(object):
 
         self.gridLayout_4.addWidget(self.progression_sand_sea_goddess, 2, 2, 1, 1)
 
+        self.groupBox_4 = QGroupBox(self.centralwidget)
+        self.groupBox_4.setObjectName(u"groupBox_4")
+        self.groupBox_4.setGeometry(QRect(10, 80, 931, 51))
+        self.horizontalLayoutWidget_3 = QWidget(self.groupBox_4)
+        self.horizontalLayoutWidget_3.setObjectName(u"horizontalLayoutWidget_3")
+        self.horizontalLayoutWidget_3.setGeometry(QRect(10, 20, 911, 21))
+        self.horizontalLayout_4 = QHBoxLayout(self.horizontalLayoutWidget_3)
+        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.horizontalLayout_4.setContentsMargins(0, 0, 0, 0)
+        self.progression_skyloft = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_skyloft.setObjectName(u"progression_skyloft")
+
+        self.horizontalLayout_4.addWidget(self.progression_skyloft)
+
+        self.progression_sky = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_sky.setObjectName(u"progression_sky")
+
+        self.horizontalLayout_4.addWidget(self.progression_sky)
+
+        self.progression_thunderhead = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_thunderhead.setObjectName(u"progression_thunderhead")
+
+        self.horizontalLayout_4.addWidget(self.progression_thunderhead)
+
+        self.progression_lanayru = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_lanayru.setObjectName(u"progression_lanayru")
+
+        self.horizontalLayout_4.addWidget(self.progression_lanayru)
+
+        self.progression_eldin = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_eldin.setObjectName(u"progression_eldin")
+
+        self.horizontalLayout_4.addWidget(self.progression_eldin)
+
+        self.progression_faron = QCheckBox(self.horizontalLayoutWidget_3)
+        self.progression_faron.setObjectName(u"progression_faron")
+
+        self.horizontalLayout_4.addWidget(self.progression_faron)
+
         MainWindow.setCentralWidget(self.centralwidget)
 
         self.retranslateUi(MainWindow)
@@ -367,7 +381,6 @@ class Ui_MainWindow(object):
         self.label_3.setText(QCoreApplication.translate("MainWindow", u"Seed", None))
         self.ouput_folder_browse_button.setText(QCoreApplication.translate("MainWindow", u"Browse", None))
         self.groupBox.setTitle(QCoreApplication.translate("MainWindow", u"Where should progress items appear?", None))
-        self.progression_sky.setText(QCoreApplication.translate("MainWindow", u"The Sky", None))
         self.progression_short.setText(QCoreApplication.translate("MainWindow", u"Short Quests", None))
         self.progression_miscellaneous.setText(QCoreApplication.translate("MainWindow", u"Miscellaneous", None))
         self.progression_free_gift.setText(QCoreApplication.translate("MainWindow", u"Free Gifts", None))
@@ -376,10 +389,6 @@ class Ui_MainWindow(object):
         self.progression_silent_realm.setText(QCoreApplication.translate("MainWindow", u"Silent Realms", None))
         self.progression_freestanding.setText(QCoreApplication.translate("MainWindow", u"Freestanding Items", None))
         self.progression_long.setText(QCoreApplication.translate("MainWindow", u"Long Quests", None))
-        self.progression_faron.setText(QCoreApplication.translate("MainWindow", u"Faron", None))
-        self.progression_eldin.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
-        self.progression_lanayru.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
-        self.progression_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
         self.progression_dungeon.setText(QCoreApplication.translate("MainWindow", u"Dungeons", None))
         self.progression_minigame.setText(QCoreApplication.translate("MainWindow", u"Minigames", None))
         self.progression_digging.setText(QCoreApplication.translate("MainWindow", u"Digging Spots", None))
@@ -412,5 +421,12 @@ class Ui_MainWindow(object):
         self.progression_floria_goddess.setText(QCoreApplication.translate("MainWindow", u"Lake Floria", None))
         self.progression_summit_goddess.setText(QCoreApplication.translate("MainWindow", u"Volcano Summit", None))
         self.progression_sand_sea_goddess.setText(QCoreApplication.translate("MainWindow", u"Sand Sea", None))
+        self.groupBox_4.setTitle(QCoreApplication.translate("MainWindow", u"What areas of the world should progress items appear?", None))
+        self.progression_skyloft.setText(QCoreApplication.translate("MainWindow", u"Skyloft", None))
+        self.progression_sky.setText(QCoreApplication.translate("MainWindow", u"The Sky", None))
+        self.progression_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Thunderhead", None))
+        self.progression_lanayru.setText(QCoreApplication.translate("MainWindow", u"Lanayru", None))
+        self.progression_eldin.setText(QCoreApplication.translate("MainWindow", u"Eldin", None))
+        self.progression_faron.setText(QCoreApplication.translate("MainWindow", u"Faron", None))
     # retranslateUi
 


### PR DESCRIPTION
Here's a semi detailed breakdown of the changes, look at the code for all the details
Added the following types:
- Skyloft
- Sky
- Thunderhead
- Faron
- Eldin
- Lanayru
- Mini Dungeons
- Free Gifts
- Free Standing Items
- Miscellaneous
- Digging Spots
- Bombable Walls
- Combat Rewards
- Songs
- Spiral Charge Chests
- Short Quests
- Long Quests
- Fetch Quests
- Crystal Quests

Removed the following types:
- Short Sidequests
- Main Quest
- Overworld

Reworked Goddess Cube Options
- Can still be enabled/disabled as a whole
- Can be enabled/disabled on a region by region basis
- Each region is split into 2, the main region (usually containing 6 cubes) and the late game region (usually containing 3)
- Regions are: Faron (7) and Lake Floria (2), Eldin (6) and Volcano Summit (3), and Lanayru (6 including Gorge cube for now) and Sand Sea (3)
- Disabling Goddess Cubes will disable the individual region checkboxes

Additional Changes:
- Changed all checks to reflect these new types. Some checks not currently used are updated as well
- Changed the GUI layout
- Updated the UI file to have all the current options (rather than just the generated `.py` file
- Added and updated GUI help text for each check type

Notes:
- Regions and Digging Spots are the only check type that impact dungeons. The rest are strictly limited to the overworld