### PR TITLE
Water Dragon Healing Patch & RBM fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+
+## Dev
+### Options
+- Added "Heal Water Dragon" option
+### Changes
+- Added crest back in Goddess Statue (to RBM 2x02)
+- Added layer 0 Sealed Grounds Spiral for tunicless files
+- Added layer 1 Behind the Temple for tunicless files
+- Added layer 0 Faron Woods for tunicless files
+- Set Skyview Spring to layer 4 for sacred water
+- Added a bomb flower behind rock guarding Goddess Cube west of Earth Temple (for Eldin Out of Bounds)
+### Bugfixes
+- Fixed grammar in Pumm's text
+
 ## 1.0.6
 ### Options
 - Added option to randomize beetles shop

--- a/SS Rando Logic - Macros.yaml
+++ b/SS Rando Logic - Macros.yaml
@@ -202,12 +202,15 @@ Can Access Skyview 2:
 
 Can Beat Skyview 2:
     Can Access Skyview 2 & Can Beat Skyview
+
+Can Heal Water Dragon:
+    (Can Beat Skyview & Bottle) | Option "heal-water-dragon" Disabled
                                                                                                                                 
 # Can Get Sacred Water:
 #     Can Beat Skyview 2 & Bottle
 
 Can Access Dungeon Entrance In Lake Floria: #if requiring Sacred Water, make sure the randomizer places the skyview boss key before
-    Can Access Lake Floria
+    Can Access Lake Floria & Can Heal Water Dragon
 
 Can Lower Ancient Cistern Statue:
     Whip & (Clawshots | (Water Scale & (Bow | Beetle) & AC Small Key x2))

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -994,7 +994,7 @@
       next: 520
   - name: New text Option
     type: textadd
-    text: "Hey, you look like you have a Questions?\n[1]Levias[2-]Other Things"
+    text: "Hey, you look like you've got a question.\n[1]Levias[2-]Other Things"
   - name: Show new Text Option
     type: flowadd
     flow:

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -586,7 +586,7 @@
         <rect>
          <x>10</x>
          <y>19</y>
-         <width>170</width>
+         <width>172</width>
          <height>213</height>
         </rect>
        </property>
@@ -703,7 +703,7 @@
         <rect>
          <x>10</x>
          <y>20</y>
-         <width>162</width>
+         <width>164</width>
          <height>204</height>
         </rect>
        </property>
@@ -856,7 +856,7 @@
         <rect>
          <x>10</x>
          <y>20</y>
-         <width>151</width>
+         <width>160</width>
          <height>201</height>
         </rect>
        </property>
@@ -909,6 +909,13 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="option_heal_water_dragon">
+          <property name="text">
+           <string>Heal Water Dragon</string>
+          </property>
+         </widget>
         </item>
         <item>
          <spacer name="verticalSpacer_2">
@@ -1203,7 +1210,7 @@
          <x>10</x>
          <y>20</y>
          <width>161</width>
-         <height>183</height>
+         <height>200</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_22">

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randogui.ui'
 ##
-## Created by: Qt User Interface Compiler version 5.15.1
+## Created by: Qt User Interface Compiler version 5.15.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -372,7 +372,7 @@ class Ui_MainWindow(object):
         self.groupBox_5.setGeometry(QRect(10, 10, 181, 231))
         self.verticalLayoutWidget = QWidget(self.groupBox_5)
         self.verticalLayoutWidget.setObjectName(u"verticalLayoutWidget")
-        self.verticalLayoutWidget.setGeometry(QRect(10, 19, 170, 213))
+        self.verticalLayoutWidget.setGeometry(QRect(10, 19, 172, 213))
         self.verticalLayout = QVBoxLayout(self.verticalLayoutWidget)
         self.verticalLayout.setObjectName(u"verticalLayout")
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
@@ -457,7 +457,7 @@ class Ui_MainWindow(object):
         self.groupBox_7.setGeometry(QRect(560, 10, 181, 231))
         self.verticalLayoutWidget_7 = QWidget(self.groupBox_7)
         self.verticalLayoutWidget_7.setObjectName(u"verticalLayoutWidget_7")
-        self.verticalLayoutWidget_7.setGeometry(QRect(10, 20, 162, 204))
+        self.verticalLayoutWidget_7.setGeometry(QRect(10, 20, 164, 204))
         self.verticalLayout_10 = QVBoxLayout(self.verticalLayoutWidget_7)
         self.verticalLayout_10.setObjectName(u"verticalLayout_10")
         self.verticalLayout_10.setContentsMargins(0, 0, 0, 0)
@@ -553,7 +553,7 @@ class Ui_MainWindow(object):
         self.groupBox_2.setGeometry(QRect(200, 10, 171, 231))
         self.verticalLayoutWidget_2 = QWidget(self.groupBox_2)
         self.verticalLayoutWidget_2.setObjectName(u"verticalLayoutWidget_2")
-        self.verticalLayoutWidget_2.setGeometry(QRect(10, 20, 151, 201))
+        self.verticalLayoutWidget_2.setGeometry(QRect(10, 20, 160, 201))
         self.verticalLayout_2 = QVBoxLayout(self.verticalLayoutWidget_2)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
         self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
@@ -602,6 +602,11 @@ class Ui_MainWindow(object):
 
 
         self.verticalLayout_2.addLayout(self.horizontalLayout_10)
+
+        self.option_heal_water_dragon = QCheckBox(self.verticalLayoutWidget_2)
+        self.option_heal_water_dragon.setObjectName(u"option_heal_water_dragon")
+
+        self.verticalLayout_2.addWidget(self.option_heal_water_dragon)
 
         self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
@@ -794,7 +799,7 @@ class Ui_MainWindow(object):
         self.groupBox_10.setGeometry(QRect(10, 10, 181, 201))
         self.verticalLayoutWidget_12 = QWidget(self.groupBox_10)
         self.verticalLayoutWidget_12.setObjectName(u"verticalLayoutWidget_12")
-        self.verticalLayoutWidget_12.setGeometry(QRect(10, 20, 161, 183))
+        self.verticalLayoutWidget_12.setGeometry(QRect(10, 20, 161, 200))
         self.verticalLayout_22 = QVBoxLayout(self.verticalLayoutWidget_12)
         self.verticalLayout_22.setObjectName(u"verticalLayout_22")
         self.verticalLayout_22.setContentsMargins(0, 0, 0, 0)
@@ -1031,6 +1036,7 @@ class Ui_MainWindow(object):
         self.label_for_option_open_thunderhead.setText(QCoreApplication.translate("MainWindow", u"Open Thunderhead", None))
         self.label_for_option_open_lmf.setText(QCoreApplication.translate("MainWindow", u"Open Lanayru Mining Facility", None))
         self.label_for_option_starting_tablet_count.setText(QCoreApplication.translate("MainWindow", u"Starting Tablets", None))
+        self.option_heal_water_dragon.setText(QCoreApplication.translate("MainWindow", u"Heal Water Dragon", None))
         self.groupBox_6.setTitle(QCoreApplication.translate("MainWindow", u"Overworld", None))
         self.label_for_option_randomize_entrances.setText(QCoreApplication.translate("MainWindow", u"Randomize Entrances", None))
         self.option_randomize_entrances.setCurrentText("")

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -62,7 +62,7 @@ class Logic:
       
       # checks outside locations that require dungeons:
       if self.rando.entrance_connections["Dungeon Entrance In Lanayru Desert"] in self.rando.non_required_dungeons:
-        self.racemode_ban_location('Skyloft - Fledge\'s Crystals')
+        self.racemode_ban_location('Skyloft Academy - Fledge\'s Crystals')
       if 'Skyview' in self.rando.non_required_dungeons:
         # TODO: check again with entrance rando
         self.racemode_ban_location('Sky - Lumpy Pumpkin Roof Goddess Chest')

--- a/options.yaml
+++ b/options.yaml
@@ -256,6 +256,14 @@
   help: Controls the conditions for opening LMF. Nodes requires activating the 3 nodes as in vanilla,
     Hook Beetle will raise LMF once the Hook Beetle is obtained.
   ui: option_open_lmf
+- name: Heal Water Dragon
+  command: heal-water-dragon
+  type: boolean
+  bits: 2
+  default: false
+  help: If checked, getting sacred water from Skyview Spring is required to heal the Water Dragon to
+    enter Ancient Cistern.
+  ui: option_heal_water_dragon
 - name: Horde
   command: horde
   type: boolean

--- a/patches.yaml
+++ b/patches.yaml
@@ -28,6 +28,8 @@ global:
     - 519 # Updated Sand Sea map
     - 115 # Full Lake Floria map
     - 180 # Thrill digger entrance CS
+    - 148 # Link looking around cutscene in Sealed Temple (for bokos in BtT)
+    - 64 # Water Dragon quest started
   startitems: # careful, items are NOT progressive here (only set item flag, no text), storyflag for upgrade has to be set manually
     - 15 # sailcloth
   startsceneflags: # currently only for skyloft
@@ -102,6 +104,12 @@ B100:
     room: 0
     objtype: STAG
 B100_1: # skyview spring
+  - name: Layer override
+    type: layeroverride
+    override:
+      - story_flag: -1
+        night: 0
+        layer: 4
   - name: Fi text after skyview CS
     type: objpatch
     id: 0xFC73
@@ -766,12 +774,6 @@ F008r: # Goddess Statue
     layer: 0
     room: 0
     objtype: OBJ
-  - name: Delete Crest
-    type: objdelete
-    id: 0xFC02
-    layer: 0
-    room: 0
-    objtype: OBJ
 F010r: # Isle of songs tower
   - name: Delete Faron Trial Dowsing
     type: objdelete
@@ -855,14 +857,6 @@ F020: # Sky
     type: oarcdelete
     oarc: GetSpareBombBagA
     layer: 0
-  - name: unnecessary oarcs
-    type: oarcdelete
-    oarc: WaterPotWater
-    layer: 2
-  - name: unnecessary oarcs
-    type: oarcdelete
-    oarc: Waterpot
-    layer: 2
   - name: unnecessary oarcs
     type: oarcdelete
     oarc: Pinwheel
@@ -962,9 +956,12 @@ F100: # Faron main area
       - story_flag: 479 #owlan quest started
         night: 0
         layer: 5
-      - story_flag: -1
+      - story_flag: 36
         night: 0
         layer: 1
+      - story_flag: -1
+        night: 0
+        layer: 0
   - name: Yerbal
     type: objmove
     id: 0x52B6
@@ -1101,6 +1098,7 @@ F101: # Deep Woods
     objtype: OBJ
 F102_1: # Outside AC
   - name: Layer override
+    onlyif: Option "heal-water-dragon" Disabled # No Water Dragon Quest
     type: layeroverride
     override: # change layer 3 trigger, no layer 1
       - story_flag: 900 # new beat AC
@@ -1109,9 +1107,28 @@ F102_1: # Outside AC
       - story_flag: 155 # AC intro cs
         night: 0
         layer: 2
-      - story_flag: -1
+      - story_flag: 36 # Tunic
         night: 0
         layer: 0
+      - story_flag: -1
+        night: 0
+        layer: 1
+  - name: Layer override
+    onlyif: Option "heal-water-dragon" Enabled # Water Dragon Quest
+    type: layeroverride
+    override: # change layer 3 trigger, no layer 1
+      - story_flag: 900 # new beat AC
+        night: 0
+        layer: 3
+      - story_flag: 155 # AC intro cs
+        night: 0
+        layer: 2
+      - story_flag: 36 # Tunic
+        night: 0
+        layer: 1
+      - story_flag: -1
+        night: 0
+        layer: 1
   - name: Water Dragon trigger after AC
     type: objpatch
     id: 0xFC59
@@ -1120,6 +1137,21 @@ F102_1: # Outside AC
     objtype: OBJ
     object:
       trigstoryfid: 900 # new AC beat flag
+F102_2: # Water Dragon's Lair
+  - name: Layer override
+    onlyif: Option "heal-water-dragon" Enabled # Water Dragon Quest
+    type: layeroverride
+    override: # Layer 1 for the Water Dragon
+      - story_flag: -1
+        night: 0
+        layer: 1 
+  - name: Layer override
+    onlyif: Option "heal-water-dragon" Disabled # No Water Dragon Quest
+    type: layeroverride
+    override: # No need for Water Dragon
+      - story_flag: -1
+        night: 0
+        layer: 0
 F102: # lake Floria
   - name: Layer override
     type: layeroverride
@@ -1632,6 +1664,22 @@ F200: # Eldin main area
     type: oarcadd
     oarc: GossipStone
     destlayer: 0
+  - name: extra Bomb flower # Deathwarp if getting cube via Eldin OoB
+    type: objadd
+    layer: 0
+    room: 4
+    objtype: OBJ
+    object:
+      params1: 0xFFFFFFF0
+      params2: 0xFFFFFFFF
+      posx: -4717
+      posy: 14600
+      posz: -24954
+      anglex: 0
+      angley: 0
+      anglez: 0
+      id: 0xFD99
+      name: Bombf
 F210: # Mogma Turf
   - name: Layer override
     type: layeroverride
@@ -2772,9 +2820,12 @@ F401: # Sealed grounds Whirlpool
       - story_flag: 13
         night: 0
         layer: 3
-      - story_flag: -1
+      - story_flag: 36
         night: 0
         layer: 1
+      - story_flag: -1
+        night: 0
+        layer: 0
   - name: Nightmare Cs 1
     type: objdelete
     id: 0xFC9C
@@ -2865,7 +2916,7 @@ F400: # Behind the Temple
         layer: 2
       - story_flag: -1
         night: 0
-        layer: 0
+        layer: 1
   - name: Goron doesn't Disapear after Sandship 1
     type: objpatch
     id: 0xFC95


### PR DESCRIPTION
Added an option to turn on healing the water dragon, which requires sacred water to access Ancient Cistern
Fixed various layers and objects to allow for more instances of RBM