### PR TITLE
Include Temple of Time area in Lanayru Desert hint-region

### DIFF
--- a/dump.yaml
+++ b/dump.yaml
@@ -6145,7 +6145,7 @@ areas:
           entrances: []
           exits:
             Shared Statue Exit: 'False'
-          hint_region: null
+          hint_region: Lanayru Desert
           locations: {}
           name: \Lanayru\Temple of Time
           sub_areas:
@@ -6163,7 +6163,7 @@ areas:
                   East\Unlock Statue
                 \Lanayru\Temple of Time\Front: "\\Hook Beetle | (\\Slingshot & Temple\
                   \ of Time - Slingshot Shot Trick)"
-              hint_region: null
+              hint_region: Lanayru Desert
               locations:
                 Unlock Statue: 'True'
                 \Ancient Flower Farming: \Distance Activator
@@ -6180,7 +6180,7 @@ areas:
                 \Lanayru\Temple of Time\Inside: 'True'
                 \Lanayru\Temple of Time\Near Goddess Cube: \Lanayru\Temple of Time\Near
                   Goddess Cube\Timeshift Stone
-              hint_region: null
+              hint_region: Lanayru Desert
               locations:
                 Gossip Stone in Temple of Time Area: 'True'
                 Blow up Rock for Timeshift Stone: "\\Hook Beetle | (Bomb Throws Trick\
@@ -6208,7 +6208,7 @@ areas:
                   Statue
                 Exit to Lanayru Mining Facility: 'True'
                 \Lanayru\Temple of Time\Front: 'True'
-              hint_region: null
+              hint_region: Lanayru Desert
               locations:
                 Unlock Statue: 'True'
               name: \Lanayru\Temple of Time\Inside
@@ -6222,7 +6222,7 @@ areas:
               entrances: []
               exits:
                 \Lanayru\Temple of Time\North East: 'True'
-              hint_region: null
+              hint_region: Lanayru Desert
               locations:
                 Timeshift Stone: 'False'
                 Goddess Cube at Ride near Temple of Time: \Goddess Sword
@@ -6239,7 +6239,7 @@ areas:
               exits:
                 \Lanayru\Temple of Time\South East: \Distance Activator
                 North Exit to Desert: 'True'
-              hint_region: null
+              hint_region: Lanayru Desert
               locations:
                 \Ancient Flower Farming: \Distance Activator
               name: \Lanayru\Temple of Time\North East

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -268,6 +268,10 @@ Desert:
           Fire Node: Sword
 
 Temple of Time:
+  # NB: There are no hintable checks here but logic consumers
+  # may include gossip stones, goddess cubes, or exits/entrances
+  # in regions based on this hint-region
+  hint-region: Lanayru Desert
   exits:
     Shared Statue Exit: Impossible  # Common for all, so placed here
 


### PR DESCRIPTION
## What does this PR do?

The "Temple of Time" area contains a goddess cube, a gossip stone, and a bunch of exits, which (while not hintable in the rando) need to be categorized in a new-logic tracker. The hint-region is the preferred means of categorization, so this adds the "Lanayru Desert" hint-region.

## How do you test this change?

I pasted `robojumper/tot-hint-area` as the data source in the new-logic tracker and verified that the workaround to hardcode the "Temple of Time" region for some locations is unnecessary.

## Notes

* As `hint-region` is only used for actual checks and the area contains no checks, this should cause no observable changes in rando behavior.
* The [goddess chest corresponding to this cube](https://github.com/ssrando/ssrando/blob/38fc26cf81bd597d0521ada383206ff4ef700881/checks.yaml#L470-L477) has its `cube_region` specified as `Lanayru Desert` too, so there is precedent.
